### PR TITLE
CVE-2019-10135: insecure yaml load of user input

### DIFF
--- a/osbs/build/config_map_response.py
+++ b/osbs/build/config_map_response.py
@@ -50,7 +50,7 @@ class ConfigMapResponse(object):
         data_dict = {}
         for key in data:
             if self.is_yaml(key):
-                data_dict[key] = yaml.load(data[key])
+                data_dict[key] = yaml.safe_load(data[key])
             else:
                 data_dict[key] = json.loads(data[key])
 
@@ -68,5 +68,5 @@ class ConfigMapResponse(object):
             return {}
 
         if self.is_yaml(name):
-            return yaml.load(data[name]) or {}
+            return yaml.safe_load(data[name]) or {}
         return json.loads(data[name])

--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -63,7 +63,7 @@ class RepoConfiguration(object):
         if os.path.exists(file_path):
             with open(file_path) as f:
                 try:
-                    self.container = yaml.load(f) or {}
+                    self.container = yaml.safe_load(f) or {}
                 except yaml.scanner.ScannerError as e:
                     msg = ('Failed to parse YAML file "{file}": {reason}'
                            .format(file=REPO_CONTAINER_CONFIG, reason=e))


### PR DESCRIPTION
`yaml.safe_load` must be used for user input to prevent injecting
malicious objects.

Signed-off-by: Martin Bašti <mbasti@redhat.com>