### PR TITLE
build request: set a completion deadline

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -173,6 +173,10 @@ Some options are also mandatory.
 
 * `build_from` (*optional*, `string`) — build source to use, consists of 2 parts separated with delimiter ':', first part can be : image or imagestream, and second part is corresponding image or imagestream
 
+* `worker_max_run_hours` (*optional*, `int`) - the build will be cancelled if a worker process takes more than this amount of hours to build. Default is 3 hours. If the value is 0 or less, the build will not be cancelled no matter how long it takes to build
+
+* `orchestrator_max_run_hours` (*optional*, `int`) - the build will be cancelled if it is not completed across all workers within this time. Default is 4 hours. If the value is 0 or less, the build will not be cancelled no matter how long it takes to build
+
 ### `[platform:ARCH]` options
 
 * `architecture` (*optional*, `string`) — platform's GOARCH (Go language platform name). If not declared, this option assumes the name of the platform being defined.

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -714,6 +714,8 @@ class OSBS(object):
             additional_tags=repo_info.additional_tags.tags,
             git_commit_depth=repo_info.configuration.depth,
             operator_manifests_extract_platform=operator_manifests_extract_platform,
+            worker_deadline=self.build_conf.get_worker_deadline(),
+            orchestrator_deadline=self.build_conf.get_orchestor_deadline(),
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         build_request.set_repo_info(repo_info)

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -13,7 +13,8 @@ import random
 import json
 
 from osbs.constants import (DEFAULT_GIT_REF, REACTOR_CONFIG_ARRANGEMENT_VERSION,
-                            DEFAULT_CUSTOMIZE_CONF, RAND_DIGITS)
+                            DEFAULT_CUSTOMIZE_CONF, RAND_DIGITS,
+                            WORKER_MAX_RUNTIME, ORCHESTRATOR_MAX_RUNTIME)
 from osbs.exceptions import OsbsValidationException
 from osbs.utils import get_imagestreamtag_from_image, make_name_from_git, RegistryURI, utcnow
 
@@ -179,6 +180,8 @@ class BuildUserParams(BuildCommon):
         self.tags_from_yaml = BuildParam('tags_from_yaml', allow_none=True)
         self.additional_tags = BuildParam('additional_tags', allow_none=True)
         self.git_commit_depth = BuildParam('git_commit_depth', allow_none=True)
+        self.worker_deadline = BuildParam('worker_deadline', allow_none=True)
+        self.orchestrator_deadline = BuildParam('orchestrator_deadline', allow_none=True)
 
         self.required_params = [
             self.build_json_dir,
@@ -209,6 +212,7 @@ class BuildUserParams(BuildCommon):
                    isolated=None, scratch=None, parent_images_digests=None,
                    tags_from_yaml=None, additional_tags=None,
                    git_commit_depth=None,
+                   worker_deadline=None, orchestrator_deadline=None,
                    operator_manifests_extract_platform=None, **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
@@ -279,6 +283,15 @@ class BuildUserParams(BuildCommon):
         self.yum_repourls.value = yum_repourls or []
         self.signing_intent.value = signing_intent
         self.compose_ids.value = compose_ids or []
+
+        try:
+            self.orchestrator_deadline.value = int(orchestrator_deadline)
+        except (ValueError, TypeError):
+            self.orchestrator_deadline.value = ORCHESTRATOR_MAX_RUNTIME
+        try:
+            self.worker_deadline.value = int(worker_deadline)
+        except (ValueError, TypeError):
+            self.worker_deadline.value = WORKER_MAX_RUNTIME
 
         self._populate_image_tag()
 

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -19,7 +19,8 @@ from six.moves.urllib.parse import urljoin
 
 from osbs.constants import (DEFAULT_CONFIGURATION_FILE, DEFAULT_CONFIGURATION_SECTION,
                             GENERAL_CONFIGURATION_SECTION, DEFAULT_NAMESPACE,
-                            DEFAULT_ARRANGEMENT_VERSION, REACTOR_CONFIG_ARRANGEMENT_VERSION)
+                            DEFAULT_ARRANGEMENT_VERSION, REACTOR_CONFIG_ARRANGEMENT_VERSION,
+                            WORKER_MAX_RUNTIME, ORCHESTRATOR_MAX_RUNTIME)
 from osbs.exceptions import OsbsValidationException
 from osbs import utils
 
@@ -622,3 +623,11 @@ class Configuration(object):
     def get_reactor_config_map(self):
         return self._get_value("reactor_config_map", self.conf_section,
                                "reactor_config_map")
+
+    def get_worker_deadline(self):
+        return self._get_value("worker_max_run_hours", self.conf_section, "worker_max_run_hours",
+                               WORKER_MAX_RUNTIME)
+
+    def get_orchestor_deadline(self):
+        return self._get_value("orchestrator_max_run_hours", self.conf_section,
+                               "orchestrator_max_run_hours", ORCHESTRATOR_MAX_RUNTIME)

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -122,3 +122,7 @@ GIT_BACKOFF_FACTOR = 60
 # number of deepen operations to attempt if a requested commit is not
 # in the shallow depth of the original clone
 GIT_FETCH_RETRY = 9
+
+# completion deadlin in hours
+WORKER_MAX_RUNTIME = 3
+ORCHESTRATOR_MAX_RUNTIME = 4

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -231,6 +231,7 @@ class TestBuildUserParams(object):
             'isolated': False,
             'koji_parent_build': 'fedora-26-9',
             'koji_target': 'tothepoint',
+            "orchestrator_deadline": 4,
             'parent_images_digests': {
                 'registry.fedorahosted.org/fedora:29': {
                     'x86_64': 'registry.fedorahosted.org/fedora@sha256:8b96f2f9f88179a065738b2b37'
@@ -249,6 +250,7 @@ class TestBuildUserParams(object):
             'trigger_imagestreamtag': 'base_image:latest',
             'user': TEST_USER,
             # 'yum_repourls': ,  # not used with compose_ids
+            "worker_deadline": 3,
         }
         # additional values that BuildUserParams requires but stores under different names
         param_kwargs.update({
@@ -287,6 +289,7 @@ class TestBuildUserParams(object):
             "koji_parent_build": "fedora-26-9",
             "koji_target": "tothepoint",
             "name": "path-master-cd1e4",
+            "orchestrator_deadline": 4,
             'parent_images_digests': {
                 'registry.fedorahosted.org/fedora:29': {
                     'x86_64': 'registry.fedorahosted.org/fedora@sha256:8b96f2f9f88179a065738b2b37'
@@ -299,7 +302,8 @@ class TestBuildUserParams(object):
             "reactor_config_override": "reactor-config-override",
             "release": "29",
             "trigger_imagestreamtag": "buildroot:old",
-            "user": TEST_USER
+            "user": TEST_USER,
+            "worker_deadline": 3,
         }
         assert spec.to_json() == json.dumps(expected_json, sort_keys=True)
 
@@ -333,6 +337,7 @@ class TestBuildUserParams(object):
             "koji_parent_build": "fedora-26-9",
             "koji_target": "tothepoint",
             "name": "path-master-cd1e4",
+            "orchestrator_deadline": 4,
             "platform": "x86_64",
             "platforms": ["x86_64"],
             "reactor_config_map": "reactor-config-map",
@@ -340,6 +345,7 @@ class TestBuildUserParams(object):
             "release": "29",
             "trigger_imagestreamtag": "buildroot:old",
             "this is not a valid key": "this is not a valid field",
-            "user": TEST_USER
+            "user": TEST_USER,
+            "worker_deadline": 3,
         }
         spec.from_json(json.dumps(expected_json))


### PR DESCRIPTION
For osbs #7519

Set a completionDeadline of 3 hours in a worker or 4 hours in the orchestrator.  This should automatically cancel stuck builds.  Alternate values can be set in the config file and the deadline can be disabled altogether by using negative values.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>