### PR TITLE
Use repr when printing logs for cli builds

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -345,7 +345,7 @@ def cmd_build(args, osbs):
         print("Build submitted (%s), watching logs (feel free to interrupt)" % build_id)
         try:
             for line in build_logs:
-                print(line)
+                print('{!r}'.format(line))
         except Exception as ex:
             logger.error("Error during fetching logs for build %s: %s", build_id, repr(ex))
 


### PR DESCRIPTION
This will prevent encoding errors when running osbs-client CLI

* OSBS-6632

Signed-off-by: Athos Ribeiro <athos@redhat.com>