### PR TITLE
utils: better error message when we fail to parse registry URI

### DIFF
--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -61,7 +61,10 @@ class RegistryURI(object):
     versionre = re.compile(r'((https?://)?([^/]*))(/(v\d+)?)?$')
 
     def __init__(self, uri):
-        groups = self.versionre.match(uri).groups()
+        match = self.versionre.match(uri)
+        if not match:
+            raise ValueError('Invalid registry URI {}'.format(uri))
+        groups = match.groups()
         self.docker_uri = groups[2]
         self.version = groups[4] or 'v2'
         self.scheme = groups[1] or ''


### PR DESCRIPTION
Prior to this change, when a user specified a registry URI that completely fails to match our validation regex, `match()` returned None, and we called `.groups()` on that `None` value. This led to the following error message:

```
osbs.exceptions.OsbsException: AttributeError("'NoneType' object has no attribute 'groups'")
```

Handle the case where our regex does not match the user input and raise
a more helpful error message to the user.

Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates