### PR TITLE
user_params: better error for missing ":" in build-from

### DIFF
--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -244,6 +244,9 @@ class BuildUserParams(BuildCommon):
                            "use build_from instead")
 
         if build_from:
+            if ':' not in build_from:
+                raise OsbsValidationException(
+                        'build_from must be "source_type:source_value"')
             source_type, source_value = build_from.split(':', 1)
             if source_type not in ('image', 'imagestream'):
                 raise OsbsValidationException(

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -168,6 +168,16 @@ class TestBuildUserParams(object):
         with pytest.raises(OsbsValidationException):
             spec.set_params(**kwargs)
 
+    def test_user_params_bad_build_from(self):
+        kwargs = self.get_minimal_kwargs()
+        # does not have an "image:" prefix:
+        kwargs['build_from'] = 'registry.example.com/buildroot'
+        spec = BuildUserParams()
+
+        with pytest.raises(OsbsValidationException) as e:
+            spec.set_params(**kwargs)
+        assert 'build_from must be "source_type:source_value"' in str(e.value)
+
     @pytest.mark.parametrize(('signing_intent', 'compose_ids', 'yum_repourls', 'exc'), (
         ('release', [1, 2], ['http://example.com/my.repo'], OsbsValidationException),
         ('release', [1, 2], None, OsbsValidationException),


### PR DESCRIPTION
Prior to this change, when a user specified a `--build-from` option that does not contain a "`:`" character, `split()` returned one value, but we tried to assign the result to two values (`source_type` and `source_value`). This led to the following error:

```
  osbs.exceptions.OsbsException: ValueError('not enough values to unpack (expected 2, got 1)')
```

Handle the case where the user fails to specify "`:`" by returning a more helpful error message to the user.


Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates