### PR TITLE
Sources containers user build params

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from types import GeneratorType
 
 from osbs.build.build_requestv2 import BuildRequestV2
-from osbs.build.user_params import BuildUserParams
+from osbs.build.user_params import load_user_params_from_json
 from osbs.build.plugins_configuration import PluginsConfiguration
 from osbs.build.build_response import BuildResponse
 from osbs.build.pod_response import PodResponse
@@ -1333,7 +1333,7 @@ class OSBS(object):
 
     @osbsapi
     def render_plugins_configuration(self, user_params_json):
-        user_params = BuildUserParams()
-        user_params.from_json(user_params_json)
+        user_params = load_user_params_from_json(user_params_json)
 
+        # TODO use different plugin configuration
         return PluginsConfiguration(user_params).render()

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -350,3 +350,31 @@ class BuildUserParams(BuildCommon):
         self.yum_repourls.value = yum_repourls or []
         self.signing_intent.value = signing_intent
         self.compose_ids.value = compose_ids or []
+
+
+class SourceContainerUserParams(BuildCommon):
+    """User params for building source containers"""
+
+    def __init__(self, build_json_dir=None):
+        super(SourceContainerUserParams, self).__init__(
+            build_json_dir=build_json_dir)
+        self.sources_for_koji_build_nvr = BuildParam("sources_for_koji_build_nvr")
+
+        self.required_params.extend([
+            self.sources_for_koji_build_nvr,
+        ])
+
+        self.attrs_finalizer()
+
+    def set_params(
+        self,
+        sources_for_koji_build_nvr=None,
+        **kwargs
+    ):
+        """
+        :param str sources_for_koji_build_nvr: NVR of build that will be used
+                                               to fetch sources
+        :return:
+        """
+        super(SourceContainerUserParams, self).set_params(**kwargs)
+        self.sources_for_koji_build_nvr.value = sources_for_koji_build_nvr

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -133,9 +133,12 @@ class BuildCommon(object):
         return 'DEFINE_KIND_NAME_IN_SUBCLASS'
 
     def __init__(self, build_json_dir=None):
-        self.arrangement_version = BuildParam("arrangement_version", allow_none=True)
+        self.arrangement_version = BuildParam(
+            "arrangement_version",
+            allow_none=True,
+            default=REACTOR_CONFIG_ARRANGEMENT_VERSION)
         self.build_json_dir = BuildParam('build_json_dir', default=build_json_dir)
-        self.kind = BuildParam(KIND_KEY)
+        self.kind = BuildParam(KIND_KEY, default=self.KIND)
         self.component = BuildParam('component')
         self.filesystem_koji_task_id = BuildParam("filesystem_koji_task_id", allow_none=True)
         self.image_tag = BuildParam("image_tag")
@@ -153,10 +156,6 @@ class BuildCommon(object):
             self.user,
         ]
         self.convert_dict = {}
-
-        # Defaults
-        self.arrangement_version.value = REACTOR_CONFIG_ARRANGEMENT_VERSION
-        self.kind.value = self.KIND
 
     def attrs_finalizer(self):
         for _, param in self.__dict__.items():

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -162,7 +162,8 @@ class BuildCommon(object):
             if isinstance(param, BuildParam):
                 # check that every parameter has a unique name
                 if param.name in self.convert_dict:
-                    raise OsbsValidationException('Two user params with the same name')
+                    raise OsbsValidationException(
+                        'Two user params with the same name: {}'.format(param.name))
                 self.convert_dict[param.name] = param
 
     def set_params(

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -20,6 +20,7 @@ from osbs.build.user_params import (
     RegistryURIsParam,
     BuildUserParams,
     SourceContainerUserParams,
+    load_user_params_from_json,
 )
 from osbs.exceptions import OsbsValidationException
 from osbs.constants import BUILD_TYPE_WORKER, REACTOR_CONFIG_ARRANGEMENT_VERSION
@@ -142,7 +143,8 @@ class TestBuildUserParams(object):
         required_json = json.dumps({
             'arrangement_version': 6,
             'customize_conf': 'worker_customize.json',
-            'git_ref': 'master'
+            'git_ref': 'master',
+            'kind': 'build_user_params',
         }, sort_keys=True)
         spec = BuildUserParams()
 
@@ -301,6 +303,7 @@ class TestBuildUserParams(object):
             "image_tag": "{}/{}:tothepoint-{}-{}-x86_64".format(TEST_USER, TEST_COMPONENT,
                                                                 rand, timestr),
             "imagestream_name": "name_label",
+            "kind": "build_user_params",
             "koji_parent_build": "fedora-26-9",
             "koji_target": "tothepoint",
             "name": "path-master-cd1e4",
@@ -419,6 +422,7 @@ class TestSourceContainerUserParams(object):
             'component': TEST_COMPONENT,
             "image_tag": "{}/{}:tothepoint-{}-{}-x86_64".format(
                 TEST_USER, TEST_COMPONENT, rand, timestr),
+            "kind": "source_containers_user_params",
             "koji_target": "tothepoint",
             "orchestrator_deadline": 5,
             "platform": "x86_64",
@@ -431,3 +435,13 @@ class TestSourceContainerUserParams(object):
         spec2 = SourceContainerUserParams()
         spec2.from_json(spec.to_json())
         assert spec2.to_json() == json.dumps(expected_json, sort_keys=True)
+
+
+@pytest.mark.parametrize('user_params,expected', [
+    ({"kind": "build_user_params"}, BuildUserParams),
+    ({"kind": "source_containers_user_params"}, SourceContainerUserParams),
+])
+def test_load_user_params_from_json(user_params, expected):
+    user_params_json = json.dumps(user_params)
+    user_params_obj = load_user_params_from_json(user_params_json)
+    assert isinstance(user_params_obj, expected)


### PR DESCRIPTION
TODO:
- [ ] <s>atomic-reactor user_params.json needs update or create a new jsonschema for source containers</s>

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
