### PR TITLE
cli: show default config options in --help

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -789,9 +789,12 @@ def cli():
     parser.add_argument("--source-registry-uri", action='store', metavar="URL",
                         help="registry with base images")
     parser.add_argument("--config", action='store', metavar="PATH",
-                        help="path to configuration file", default=DEFAULT_CONFIGURATION_FILE)
+                        help="path to configuration file, default %s" % DEFAULT_CONFIGURATION_FILE,
+                        default=DEFAULT_CONFIGURATION_FILE)
     parser.add_argument("--instance", "-i", action='store', metavar="SECTION_NAME",
-                        help="section within config for requested instance",
+                        help="section within config for requested instance."
+                             " If unspecified, osbs will load the section"
+                             " named '%s'" % DEFAULT_CONFIGURATION_SECTION,
                         default=DEFAULT_CONFIGURATION_SECTION)
     parser.add_argument("--username", action='store',
                         help="name of user to use for Basic Authentication in OSBS")


### PR DESCRIPTION
Show the default `osbs.conf` and the default configuration section title ("default") path when the user runs `osbs --help`.


Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates