### PR TITLE
build: remove stray quote from debug log message

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -244,7 +244,7 @@ class PluginsConfiguration(object):
 
         enable_plugins = self.pt.customize_conf.get('enable_plugins', [])
         if not enable_plugins:
-            logger.debug('No site-user specified plugins to enable"')
+            logger.debug('No site-user specified plugins to enable')
         else:
             for plugin in enable_plugins:
                 try:


### PR DESCRIPTION
The log message is a single-quoted string. We don't need any double-quotes here.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates