### PR TITLE
User params: make BuildCommon an abstract class

### DIFF
--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -7,11 +7,13 @@ of the BSD license. See the LICENSE file for details.
 """
 from __future__ import print_function, absolute_import, unicode_literals
 
-from abc import abstractproperty
+from abc import abstractproperty, ABCMeta
 import logging
 import re
 import random
 import json
+
+import six
 
 from osbs.constants import (DEFAULT_GIT_REF, REACTOR_CONFIG_ARRANGEMENT_VERSION,
                             DEFAULT_CUSTOMIZE_CONF, RAND_DIGITS,
@@ -126,7 +128,9 @@ def load_user_params_from_json(user_params_json):
     return user_params
 
 
+@six.add_metaclass(ABCMeta)
 class BuildCommon(object):
+    """Abstract class for user parameters"""
 
     @abstractproperty
     def KIND(self):


### PR DESCRIPTION
Accidentally this class was not marked as abstract

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
