### PR TITLE
constants: fix "deadlines" spelling in comments

### DIFF
--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -123,6 +123,6 @@ GIT_BACKOFF_FACTOR = 60
 # in the shallow depth of the original clone
 GIT_FETCH_RETRY = 9
 
-# completion deadlin in hours
+# completion deadlines in hours
 WORKER_MAX_RUNTIME = 3
 ORCHESTRATOR_MAX_RUNTIME = 4


### PR DESCRIPTION
`deadlin` -> `deadlines`

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates