### PR TITLE
Source containers: render plugins configuration

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -26,7 +26,10 @@ from osbs.build.build_requestv2 import (
     SourceBuildRequest,
 )
 from osbs.build.user_params import load_user_params_from_json
-from osbs.build.plugins_configuration import PluginsConfiguration
+from osbs.build.plugins_configuration import (
+    PluginsConfiguration,
+    SourceContainerPluginsConfiguration,
+)
 from osbs.build.build_response import BuildResponse
 from osbs.build.pod_response import PodResponse
 from osbs.build.config_map_response import ConfigMapResponse
@@ -39,6 +42,8 @@ from osbs.constants import (BUILD_RUNNING_STATES, WORKER_OUTER_TEMPLATE,
                             ANNOTATION_SOURCE_REPO, ANNOTATION_INSECURE_REPO, FILTER_KEY,
                             RELEASE_LABEL_FORMAT,
                             ORCHESTRATOR_SOURCES_OUTER_TEMPLATE,
+                            USER_PARAMS_KIND_IMAGE_BUILDS,
+                            USER_PARAMS_KIND_SOURCE_CONTAINER_BUILDS,
                             )
 from osbs.core import Openshift
 from osbs.exceptions import (OsbsException, OsbsValidationException, OsbsResponseException,
@@ -1441,5 +1446,11 @@ class OSBS(object):
     def render_plugins_configuration(self, user_params_json):
         user_params = load_user_params_from_json(user_params_json)
 
-        # TODO use different plugin configuration
-        return PluginsConfiguration(user_params).render()
+        if user_params.KIND == USER_PARAMS_KIND_IMAGE_BUILDS:
+            return PluginsConfiguration(user_params).render()
+        elif user_params.KIND == USER_PARAMS_KIND_SOURCE_CONTAINER_BUILDS:
+            return SourceContainerPluginsConfiguration(user_params).render()
+        else:
+            raise RuntimeError(
+                "Unexpected user params kind: {}".format(user_params.KIND)
+            )

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -17,7 +17,10 @@ import six
 
 from osbs.constants import (DEFAULT_GIT_REF, REACTOR_CONFIG_ARRANGEMENT_VERSION,
                             DEFAULT_CUSTOMIZE_CONF, RAND_DIGITS,
-                            WORKER_MAX_RUNTIME, ORCHESTRATOR_MAX_RUNTIME)
+                            WORKER_MAX_RUNTIME, ORCHESTRATOR_MAX_RUNTIME,
+                            USER_PARAMS_KIND_IMAGE_BUILDS,
+                            USER_PARAMS_KIND_SOURCE_CONTAINER_BUILDS,
+                            )
 from osbs.exceptions import OsbsValidationException
 from osbs.utils import (
     get_imagestreamtag_from_image,
@@ -307,7 +310,7 @@ class BuildCommon(object):
 @register_user_params
 class BuildUserParams(BuildCommon):
 
-    KIND = 'build_user_params'
+    KIND = USER_PARAMS_KIND_IMAGE_BUILDS
 
     def __init__(self, build_json_dir=None, customize_conf=None):
         # defines image_tag, koji_target, filesystem_koji_task_id, platform, arrangement_version
@@ -409,7 +412,7 @@ class BuildUserParams(BuildCommon):
 class SourceContainerUserParams(BuildCommon):
     """User params for building source containers"""
 
-    KIND = 'source_containers_user_params'
+    KIND = USER_PARAMS_KIND_SOURCE_CONTAINER_BUILDS
 
     def __init__(self, build_json_dir=None):
         super(SourceContainerUserParams, self).__init__(

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -129,3 +129,6 @@ GIT_FETCH_RETRY = 9
 # completion deadlin in hours
 WORKER_MAX_RUNTIME = 3
 ORCHESTRATOR_MAX_RUNTIME = 4
+
+USER_PARAMS_KIND_IMAGE_BUILDS = 'build_user_params'
+USER_PARAMS_KIND_SOURCE_CONTAINER_BUILDS = 'source_containers_user_params'


### PR DESCRIPTION
TODO:
- [x] unittests

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
