### PR TITLE
Fix build plugin name in inner

### DIFF
--- a/inputs/orchestrator_sources_inner:6.json
+++ b/inputs/orchestrator_sources_inner:6.json
@@ -6,7 +6,7 @@
   ],
   "buildstep_plugins": [
     {
-      "name": "source_container_build"
+      "name": "source_container"
     }
   ],
   "postbuild_plugins": [],

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -881,6 +881,6 @@ class TestSourceContainerPluginsConfiguration(object):
         plugins = get_plugins_from_build_json(build_json)
 
         source_container_build = get_plugin(
-            plugins, "buildstep_plugins", "source_container_build"
+            plugins, "buildstep_plugins", "source_container"
         )
         assert source_container_build is not None


### PR DESCRIPTION
* OSBS-8040

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
