### PR TITLE
push_floating_tags: Add plugin to inputs/

### DIFF
--- a/inputs/orchestrator_inner:6.json
+++ b/inputs/orchestrator_inner:6.json
@@ -81,11 +81,14 @@
       "required": false
     },
     {
-      "name": "import_image",
-      "required": false
+      "name": "koji_import"
     },
     {
-      "name": "koji_import"
+      "name": "push_floating_tags"
+    },
+    {
+      "name": "import_image",
+      "required": false
     },
     {
       "name": "koji_tag_build"

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -299,8 +299,9 @@ class TestArrangementV6(ArrangementBase):
 
             'exit_plugins': [
                 PLUGIN_VERIFY_MEDIA_KEY,
-                'import_image',
                 PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
+                'push_floating_tags',
+                'import_image',
                 'koji_tag_build',
                 'store_metadata_in_osv3',
                 'sendmail',


### PR DESCRIPTION
Add exit_push_floating_tags to inputs/orchestrator_sources_inner:6.json,
and reorder exit_import_image to run after it.  If exit_koji_import
fails, push_floating_tags and import_image shouldn't run, but
import_image needs to run on the floating tags.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
