### PR TITLE
pass sources_for_koji_build_id to sources build

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -840,6 +840,7 @@ class OSBS(object):
         self,
         component,
         sources_for_koji_build_nvr,
+        sources_for_koji_build_id=None,
         outer_template=None,
         arrangement_version=None,
         scratch=None,
@@ -884,6 +885,7 @@ class OSBS(object):
             scratch=self.build_conf.get_scratch(scratch),
             signing_intent=signing_intent,
             sources_for_koji_build_nvr=sources_for_koji_build_nvr,
+            sources_for_koji_build_id=sources_for_koji_build_id,
             user=user,
             worker_deadline=self.build_conf.get_worker_deadline(),
         )

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -419,6 +419,7 @@ class SourceContainerUserParams(BuildCommon):
         super(SourceContainerUserParams, self).__init__(
             build_json_dir=build_json_dir)
         self.sources_for_koji_build_nvr = BuildParam("sources_for_koji_build_nvr")
+        self.sources_for_koji_build_id = BuildParam("sources_for_koji_build_id", allow_none=True)
 
         self.required_params.extend([
             self.sources_for_koji_build_nvr,
@@ -429,6 +430,7 @@ class SourceContainerUserParams(BuildCommon):
     def set_params(
         self,
         sources_for_koji_build_nvr=None,
+        sources_for_koji_build_id=None,
         **kwargs
     ):
         """
@@ -438,5 +440,6 @@ class SourceContainerUserParams(BuildCommon):
         """
         super(SourceContainerUserParams, self).set_params(**kwargs)
         self.sources_for_koji_build_nvr.value = sources_for_koji_build_nvr
+        self.sources_for_koji_build_id.value = sources_for_koji_build_id
         if sources_for_koji_build_nvr:
             self.name.value = make_source_container_name(sources_for_koji_build_nvr)

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -373,6 +373,7 @@ def cmd_build_source_container(args, osbs):
         'target': osbs.build_conf.get_koji_target(),
         'scratch': args.scratch,
         'sources_for_koji_build_nvr': args.sources_for_koji_build_nvr,
+        'sources_for_koji_build_id': args.sources_for_koji_build_id,
         'component': args.component,
     }
     if args.arrangement_version:
@@ -728,6 +729,10 @@ def cli():
     build_source_container_parser.add_argument(
         "--sources-for-koji-build-nvr", action='store', required=True,
         metavar='N-V-R',  help="koji build NVR"
+    )
+    build_source_container_parser.add_argument(
+        "--sources-for-koji-build-id", action='store',
+        help="koji build ID"
     )
     build_source_container_parser.add_argument(
         "-c", "--component", action='store', required=True,

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -392,11 +392,12 @@ class TestSourceContainerUserParams(object):
         with pytest.raises(OsbsValidationException):
             spec.validate()
 
-    @pytest.mark.parametrize('origin_nvr, final_name', [
-        ('test-1-123', 'test-source'),
-        ('test-dashed-nvr-1-123', 'test-dashed-nvr-source'),
+    @pytest.mark.parametrize('origin_nvr, final_name, origin_id', [
+        ('test-1-123', 'test-source', 12345),
+        ('test-dashed-nvr-1-123', 'test-dashed-nvr-source', 12345),
+        ('test-dashed-nvr-1-123', 'test-dashed-nvr-source', None),
     ])
-    def test_all_values_and_json(self, origin_nvr, final_name):
+    def test_all_values_and_json(self, origin_nvr, final_name, origin_id):
         param_kwargs = self.get_minimal_kwargs(origin_nvr)
         param_kwargs.update({
             'component': TEST_COMPONENT,
@@ -406,6 +407,7 @@ class TestSourceContainerUserParams(object):
             'scratch': True,
             "signing_intent": "test-signing-intent",
             "worker_deadline": 3,
+            "sources_for_koji_build_id": origin_id,
         })
 
         rand = '12345'
@@ -441,6 +443,8 @@ class TestSourceContainerUserParams(object):
             "user": TEST_USER,
             "worker_deadline": 3,
         }
+        if origin_id:
+            expected_json['sources_for_koji_build_id'] = origin_id
         assert spec.to_json() == json.dumps(expected_json, sort_keys=True)
 
         spec2 = SourceContainerUserParams()


### PR DESCRIPTION
OSBS-8041

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
