### PR TITLE
add handling for setting a release version environmental variable

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -783,6 +783,7 @@ class OSBS(object):
             tags_from_yaml=repo_info.additional_tags.from_container_yaml,
             additional_tags=repo_info.additional_tags.tags,
             git_commit_depth=repo_info.configuration.depth,
+            release_env_var=self.build_conf.get_release_env(),
             operator_manifests_extract_platform=operator_manifests_extract_platform,
             worker_deadline=self.build_conf.get_worker_deadline(),
             orchestrator_deadline=self.build_conf.get_orchestor_deadline(),

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -341,6 +341,7 @@ class BuildUserParams(BuildCommon):
         self.tags_from_yaml = BuildParam('tags_from_yaml', allow_none=True)
         self.additional_tags = BuildParam('additional_tags', allow_none=True)
         self.git_commit_depth = BuildParam('git_commit_depth', allow_none=True)
+        self.release_env_var = BuildParam('release_env_var', allow_none=True)
         self.triggered_after_koji_task = BuildParam('triggered_after_koji_task', allow_none=True)
 
         self.required_params.extend([
@@ -363,6 +364,7 @@ class BuildUserParams(BuildCommon):
                    isolated=None, parent_images_digests=None,
                    tags_from_yaml=None, additional_tags=None,
                    git_commit_depth=None,
+                   release_env_var=None,
                    operator_manifests_extract_platform=None,
                    triggered_after_koji_task=None, **kwargs):
         super(BuildUserParams, self).set_params(**kwargs)
@@ -388,6 +390,7 @@ class BuildUserParams(BuildCommon):
         self.flatpak.value = flatpak
         self.isolated.value = isolated
         self.triggered_after_koji_task.value = triggered_after_koji_task
+        self.release_env_var.value = release_env_var
 
         if not flatpak:
             if not base_image:

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -621,3 +621,6 @@ class Configuration(object):
     def get_orchestor_deadline(self):
         return self._get_value("orchestrator_max_run_hours", self.conf_section,
                                "orchestrator_max_run_hours", ORCHESTRATOR_MAX_RUNTIME)
+
+    def get_release_env(self):
+        return self._get_value("set_release_env", self.conf_section, "set_release_env")


### PR DESCRIPTION
Fixes osbs-7244

Add a new user param, release_env_var.  If it has a value, add it it to the Dockerfile after the FROM lines as an ENV with a value of the current release.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
