### PR TITLE
Source containers: enable required plugins

### DIFF
--- a/inputs/orchestrator_sources_inner:6.json
+++ b/inputs/orchestrator_sources_inner:6.json
@@ -5,6 +5,9 @@
     },
     {
       "name": "fetch_sources"
+    },
+    {
+      "name": "bump_release"
     }
   ],
   "buildstep_plugins": [
@@ -14,9 +17,30 @@
   ],
   "postbuild_plugins": [
     {
+      "name": "compress",
+      "args": {
+        "load_exported_image": true,
+        "method": "gzip"
+      }
+    },
+    {
       "name": "tag_and_push"
     }
   ],
   "prepublish_plugins": [],
-  "exit_plugins": []
+  "exit_plugins": [
+    {
+      "name": "verify_media",
+      "required": false
+    },
+    {
+      "name": "koji_import"
+    },
+    {
+      "name": "koji_tag_build"
+    },
+    {
+      "name": "remove_built_image"
+    }
+  ]
 }

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -629,7 +629,10 @@ class SourceContainerPluginsConfiguration(PluginsConfigurationBase):
         self.render_customizations()
 
         # Set parameters on each plugin as needed
+        # self.render_bump_release()  # not needed yet
         self.render_fetch_sources()
+        self.render_koji()
+        self.render_koji_tag_build()
         self.render_tag_and_push()
 
         return self.pt.to_json()


### PR DESCRIPTION
* OSBS-8040
* OSBS-8285

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
