### PR TITLE
Source container build: allow to use only build_id

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -839,7 +839,7 @@ class OSBS(object):
     def create_source_container_build(
         self,
         component,
-        sources_for_koji_build_nvr,
+        sources_for_koji_build_nvr=None,
         sources_for_koji_build_id=None,
         outer_template=None,
         arrangement_version=None,
@@ -862,8 +862,6 @@ class OSBS(object):
         )
 
         error_messages = []
-        if not sources_for_koji_build_nvr:
-            error_messages.append("required argument 'sources_for_koji_build_nvr' can't be empty")
         if not component:
             error_messages.append("required argument 'component' can't be empty")
         if error_messages:

--- a/osbs/build/build_requestv2.py
+++ b/osbs/build/build_requestv2.py
@@ -72,10 +72,7 @@ class BaseBuildRequest(object):
         if validate:
             self.user_params.validate()
 
-        self.render_name(
-            self.user_params.name.value,
-            self.user_params.image_tag.value,
-            self.user_params.platform.value)
+        self.render_name()
         self.render_output_name()
         self.render_custom_strategy()
         self.render_resource_limits()
@@ -100,11 +97,13 @@ class BaseBuildRequest(object):
         else:
             custom_strategy['from']['name'] = self.user_params.build_image.value
 
-    def render_name(self, name, image_tag, platform):
+    def render_name(self):
         """Sets the Build/BuildConfig object name"""
+        name = self.user_params.name.value
+        platform = self.user_params.platform.value
 
         if self.scratch or self.isolated:
-            name = image_tag
+            name = self.user_params.image_tag.value
             # Platform name may contain characters not allowed by OpenShift.
             if platform:
                 platform_suffix = '-{}'.format(platform)
@@ -647,15 +646,13 @@ class SourceBuildRequest(BaseBuildRequest):
     def render(self, validate=True):
         return super(SourceBuildRequest, self).render(validate=validate)
 
-    def render_name(self, name, image_tag, platform):
+    def render_name(self):
         """Sets the Build/BuildConfig object name
 
         Source container builds must have unique names, because we are not
         using buildConfigs just regular builds
-
-        platform is unused for source container images builds
         """
-        name = image_tag
+        name = self.user_params.image_tag.value
 
         _, salt, timestamp = name.rsplit('-', 2)
 

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -417,12 +417,8 @@ class SourceContainerUserParams(BuildCommon):
     def __init__(self, build_json_dir=None):
         super(SourceContainerUserParams, self).__init__(
             build_json_dir=build_json_dir)
-        self.sources_for_koji_build_nvr = BuildParam("sources_for_koji_build_nvr")
+        self.sources_for_koji_build_nvr = BuildParam("sources_for_koji_build_nvr", allow_none=True)
         self.sources_for_koji_build_id = BuildParam("sources_for_koji_build_id", allow_none=True)
-
-        self.required_params.extend([
-            self.sources_for_koji_build_nvr,
-        ])
 
         self.attrs_finalizer()
 
@@ -435,8 +431,16 @@ class SourceContainerUserParams(BuildCommon):
         """
         :param str sources_for_koji_build_nvr: NVR of build that will be used
                                                to fetch sources
+        :param int sources_for_koji_build_id: ID of build that will be used
+                                              to fetch sources
         :return:
         """
         super(SourceContainerUserParams, self).set_params(**kwargs)
+
+        if sources_for_koji_build_id is None and sources_for_koji_build_nvr is None:
+            raise OsbsValidationException(
+                "At least one param from 'sources_for_koji_build_id' or "
+                "'sources_for_koji_build_nvr' must be specified"
+            )
         self.sources_for_koji_build_nvr.value = sources_for_koji_build_nvr
         self.sources_for_koji_build_id.value = sources_for_koji_build_id

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -25,7 +25,6 @@ from osbs.exceptions import OsbsValidationException
 from osbs.utils import (
     get_imagestreamtag_from_image,
     make_name_from_git,
-    make_source_container_name,
     RegistryURI,
     utcnow)
 
@@ -159,7 +158,6 @@ class BuildCommon(object):
         self.image_tag = BuildParam("image_tag")
         self.koji_target = BuildParam("koji_target", allow_none=True)
         self.koji_task_id = BuildParam('koji_task_id', allow_none=True)
-        self.name = BuildIDParam()
         self.platform = BuildParam("platform", allow_none=True)
         self.orchestrator_deadline = BuildParam('orchestrator_deadline', allow_none=True)
         self.reactor_config_map = BuildParam("reactor_config_map", allow_none=True)
@@ -334,6 +332,7 @@ class BuildUserParams(BuildCommon):
         self.parent_images_digests = BuildParam('parent_images_digests', allow_none=True)
         self.operator_manifests_extract_platform = BuildParam('operator_manifests_extract_platform',
                                                               allow_none=True)
+        self.name = BuildIDParam()
         self.platforms = BuildParam('platforms', allow_none=True)
         self.release = BuildParam('release', allow_none=True)
         self.trigger_imagestreamtag = BuildParam('trigger_imagestreamtag')
@@ -441,5 +440,3 @@ class SourceContainerUserParams(BuildCommon):
         super(SourceContainerUserParams, self).set_params(**kwargs)
         self.sources_for_koji_build_nvr.value = sources_for_koji_build_nvr
         self.sources_for_koji_build_id.value = sources_for_koji_build_id
-        if sources_for_koji_build_nvr:
-            self.name.value = make_source_container_name(sources_for_koji_build_nvr)

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -727,11 +727,12 @@ def cli():
         help='build a source container image in OSBS'
     )
     build_source_container_parser.add_argument(
-        "--sources-for-koji-build-nvr", action='store', required=True,
+        "--sources-for-koji-build-nvr", action='store',
         metavar='N-V-R',  help="koji build NVR"
     )
     build_source_container_parser.add_argument(
         "--sources-for-koji-build-id", action='store',
+        type=int, metavar='ID',
         help="koji build ID"
     )
     build_source_container_parser.add_argument(
@@ -904,6 +905,14 @@ def cli():
     parser.add_argument("--token-file", metavar="TOKENFILE", action="store",
                         help="Read oauth 2.0 token from file")
     args = parser.parse_args()
+
+    if getattr(args, 'func', None) is cmd_build_source_container:
+        if not (args.sources_for_koji_build_id or args.sources_for_koji_build_nvr):
+            parser.error(
+                "at least one of --sources-for-koji-build-id and "
+                "--sources-for-koji-build-nvr has to be specified"
+            )
+
     return parser, args
 
 

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -518,36 +518,6 @@ def make_name_from_git(repo, branch, limit=53, separator='-', hash_size=5):
     return separator.join(filter(None, (sanitized, hash_str)))
 
 
-def make_source_container_name(nvr, limit=51, separator='-'):
-    """
-    return name string representing the given NVR
-    to be used as a build name for source container.
-
-    NOTE: Build name will be used to generate pods which have a
-    limit of 64 characters and is composed as:
-
-        <buildname>-<buildnumber>-<podsuffix>
-        rhel7-source-build
-
-    Assuming '-source' (7 chars) and '-build' (6 chars) as default
-    suffixes, name should be limited to 51 chars (64 - 13).
-
-    OpenShift is very peculiar in which BuildConfig names it
-    allows. For this reason, only certain characters are allowed.
-    Any disallowed characters will be removed from repo and
-    branch names.
-
-    :param nvr: str, NVR identifier
-    :param limit: int, max name length
-    :param separator: str, used to separate the name and 'source' suffix
-    :return: str, name representing NVR
-    """
-    name, _, _ = nvr.rsplit('-', 2)
-    sanitized = sanitize_strings_for_openshift(
-        name, limit=limit, separator=separator, label=False)
-    return separator.join((sanitized, 'source'))
-
-
 def wrap_name_from_git(prefix, suffix, *args, **kwargs):
     """
     wraps the result of make_name_from_git in a suffix and postfix

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -382,15 +382,15 @@ class TestSourceContainerUserParams(object):
         }
 
     def test_validate_missing_required(self):
+        """Missing 'sources_for_koji_build_id' and
+        `sources_for_koji_build_nvr` params"""
         kwargs = {
             "build_from": "image:buildroot:latest",
             'user': TEST_USER,
         }
         spec = SourceContainerUserParams()
-        spec.set_params(**kwargs)
-
         with pytest.raises(OsbsValidationException):
-            spec.validate()
+            spec.set_params(**kwargs)
 
     @pytest.mark.parametrize('origin_nvr, origin_id', [
         ('test-1-123', 12345),

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -392,12 +392,12 @@ class TestSourceContainerUserParams(object):
         with pytest.raises(OsbsValidationException):
             spec.validate()
 
-    @pytest.mark.parametrize('origin_nvr, final_name, origin_id', [
-        ('test-1-123', 'test-source', 12345),
-        ('test-dashed-nvr-1-123', 'test-dashed-nvr-source', 12345),
-        ('test-dashed-nvr-1-123', 'test-dashed-nvr-source', None),
+    @pytest.mark.parametrize('origin_nvr, origin_id', [
+        ('test-1-123', 12345),
+        ('test-dashed-nvr-1-123', 12345),
+        ('test-dashed-nvr-1-123', None),
     ])
-    def test_all_values_and_json(self, origin_nvr, final_name, origin_id):
+    def test_all_values_and_json(self, origin_nvr, origin_id):
         param_kwargs = self.get_minimal_kwargs(origin_nvr)
         param_kwargs.update({
             'component': TEST_COMPONENT,
@@ -436,7 +436,6 @@ class TestSourceContainerUserParams(object):
             "signing_intent": "test-signing-intent",
             "sources_for_koji_build_nvr": origin_nvr,
             "koji_target": "tothepoint",
-            "name": final_name,
             "orchestrator_deadline": 5,
             "platform": "x86_64",
             'scratch': True,


### PR DESCRIPTION

Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
