### PR TITLE
Source build doesn't need remove_image plugin anymore,

### DIFF
--- a/inputs/orchestrator_sources_inner:6.json
+++ b/inputs/orchestrator_sources_inner:6.json
@@ -38,9 +38,6 @@
     },
     {
       "name": "koji_tag_build"
-    },
-    {
-      "name": "remove_built_image"
     }
   ]
 }


### PR DESCRIPTION
because we aren't pulling image anymore

* OSBS-8322

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
