### PR TITLE
Fix race condition in watch_resource

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015, 2019 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -84,7 +84,7 @@ def cmd_watch_builds(args, osbs):
                 created = time.ctime(get_time_from_rfc3339(timestamp))
 
             b = {
-                "changetype": changetype,
+                "changetype": changetype or '(none)',
                 "name": name or '',
                 "status": status,
                 "created": created,

--- a/tests/cli/test_capture.py
+++ b/tests/cli/test_capture.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015, 2019 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -37,7 +37,12 @@ def test_json_capture_no_watch(osbs_with_capture, tmpdir):
 
 
 def test_json_capture_watch(osbs_with_capture, tmpdir):
-    osbs_with_capture.wait_for_build_to_finish(TEST_BUILD)
+    # Take the first two yielded values (fresh object, update)
+    # PyCQA/pylint#2731 fixed in 2.4.4, so noqa
+    for _ in zip(range(2),  # pylint: disable=W1638
+                 osbs_with_capture.os.watch_resource('builds', TEST_BUILD)):
+        pass
+
     filename = "get-build.openshift.io_v1_watch_namespaces_{n}_builds_{b}_-000-000.json"
     path = os.path.join(str(tmpdir), filename.format(n=DEFAULT_NAMESPACE,
                                                      b=TEST_BUILD))


### PR DESCRIPTION
OSBS-8325

Yield a fresh copy (from GET) of the object being watched after successful response from
the watch API, but before streaming data.

Signed-off-by: Tim Waugh <twaugh@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
