### PR TITLE
remove obsolete pdc code

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -71,10 +71,6 @@ Some options are also mandatory.
 
 * `odcs_ssl_secret` (*optional*, `string`) - name of [kubernetes secret](https://github.com/kubernetes/kubernetes/blob/master/docs/design/secrets.md) to use for authenticating to the ODCS instance via SSL Certificate. The secret must contain one key, called 'cert'.
 
-* `pdc_url` (*optional*, `string`) - URL for API requests for the Product Definition Center. No longer used
-
-* `pdc_insecure` (*optional*, `boolean`) - If set, valid SSL certificates will not be required for requests to `pdc_url`
-
 * `sources_command` (*optional*, `string`) — command to use to get dist-git artifacts from lookaside cache (e.g. `fedpkg sources`)
 
 * `username`, `password` (*optional*, `string`) — when OpenShift is hidden behind authentication proxy, you can specify username and password for basic authentication

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -740,8 +740,6 @@ class OSBS(object):
             odcs_insecure=self.build_conf.get_odcs_insecure(),
             odcs_openidc_secret=self.build_conf.get_odcs_openidc_secret(),
             odcs_ssl_secret=self.build_conf.get_odcs_ssl_secret(),
-            pdc_url=self.build_conf.get_pdc_url(),
-            pdc_insecure=self.build_conf.get_pdc_insecure(),
             architecture=architecture,
             platforms=platforms,
             platform=platform,

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -221,13 +221,6 @@ class Configuration(object):
     def get_odcs_ssl_secret(self):
         return self._get_deprecated("odcs_ssl_secret", self.conf_section, "odcs_ssl_secret")
 
-    def get_pdc_url(self):
-        return self._get_deprecated("pdc_url", self.conf_section, "pdc_url")
-
-    def get_pdc_insecure(self):
-        return self._get_deprecated("pdc_insecure", self.conf_section, "pdc_insecure",
-                                    default=False, is_bool_val=True)
-
     def get_kojiroot(self):
         return self._get_deprecated("koji_root", self.conf_section, "koji_root")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -535,7 +535,6 @@ def osbs(request, openshift):
             koji_hub = http://koji.example.com/kojihub
             flatpak_base_image = registry.fedoraproject.org/fedora:latest
             odcs_url = https://odcs.example.com/odcs/1
-            pdc_url = https://pdc.example.com/rest_api/v1
             use_auth = false
             can_orchestrate = true
             build_from = image:buildroot:latest


### PR DESCRIPTION
Fixes OSBS-7605

pdc support was deprecated in September 2018, so remove the last remnants
of it from the code.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

doc change at https://github.com/containerbuildsystem/osbs-docs/pull/121

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
