### PR TITLE
set koji-task-id label on source container build,

### DIFF
--- a/osbs/build/build_requestv2.py
+++ b/osbs/build/build_requestv2.py
@@ -86,6 +86,10 @@ class BaseBuildRequest(object):
         data = self.get_reactor_config_data()
         self.set_data_from_reactor_config(data)
 
+        koji_task_id = self.user_params.koji_task_id.value
+        if koji_task_id is not None:
+            self.set_label('koji-task-id', str(koji_task_id))
+
         return self.template
 
     def render_custom_strategy(self):
@@ -486,8 +490,6 @@ class BuildRequestV2(BaseBuildRequest):
 
         koji_task_id = self.user_params.koji_task_id.value
         if koji_task_id is not None:
-            self.set_label('koji-task-id', str(koji_task_id))
-
             # keep also original task for all manual builds with task
             # that way when delegated task for autorebuild will be used
             # we will still keep track of it


### PR DESCRIPTION
so it can be later used in koji_import to resolve owner

* OSBS-8380

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
