### PR TITLE
pass params to download_remote_sources plugin

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -684,6 +684,8 @@ class OSBS(object):
                               operator_manifests_extract_platform=None,
                               skip_build=False,
                               triggered_after_koji_task=None,
+                              remote_source_url=None,
+                              remote_source_build_args=None,
                               **kwargs):
 
         if flatpak:
@@ -713,6 +715,8 @@ class OSBS(object):
             git_uri=git_uri,
             git_ref=git_ref,
             git_branch=git_branch,
+            remote_source_url=remote_source_url,
+            remote_source_build_args=remote_source_build_args,
             user=user,
             component=req_labels[utils.Labels.LABEL_TYPE_COMPONENT],
             build_image=self.build_conf.get_build_image(),

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -571,6 +571,16 @@ class PluginsConfigurationBase(object):
                     self.user_params.signing_intent.value
                 )
 
+    def render_download_remote_source(self):
+        phase = 'prebuild_plugins'
+        plugin = 'download_remote_source'
+
+        if self.pt.has_plugin_conf(phase, plugin):
+            self.pt.set_plugin_arg(phase, plugin, 'remote_source_url',
+                                   self.user_params.remote_source_url.value)
+            self.pt.set_plugin_arg(phase, plugin, 'remote_source_build_args',
+                                   self.user_params.remote_source_build_args.value)
+
 
 class PluginsConfiguration(PluginsConfigurationBase):
     """Plugin configuration for image builds"""
@@ -611,6 +621,7 @@ class PluginsConfiguration(PluginsConfigurationBase):
         self.render_resolve_module_compose()
         self.render_tag_from_config()
         self.render_koji_delegate()
+        self.render_download_remote_source()
         return self.pt.to_json()
 
 

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -325,6 +325,8 @@ class BuildUserParams(BuildCommon):
         self.git_branch = BuildParam('git_branch')
         self.git_ref = BuildParam('git_ref', default=DEFAULT_GIT_REF)
         self.git_uri = BuildParam('git_uri')
+        self.remote_source_url = BuildParam('remote_source_url')
+        self.remote_source_build_args = BuildParam('remote_source_build_args')
         self.imagestream_name = BuildParam('imagestream_name')
         self.isolated = BuildParam('isolated', allow_none=True)
         self.koji_parent_build = BuildParam('koji_parent_build', allow_none=True)
@@ -352,6 +354,7 @@ class BuildUserParams(BuildCommon):
 
     def set_params(self,
                    git_uri=None, git_ref=None, git_branch=None,
+                   remote_source_url=None, remote_source_build_args=None,
                    base_image=None, name_label=None,
                    release=None,
                    platforms=None, build_type=None,
@@ -368,6 +371,8 @@ class BuildUserParams(BuildCommon):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
         self.git_branch.value = git_branch
+        self.remote_source_url.value = remote_source_url
+        self.remote_source_build_args.value = remote_source_build_args
         self.git_commit_depth.value = git_commit_depth
         self.tags_from_yaml.value = tags_from_yaml
         self.additional_tags.value = additional_tags or set()


### PR DESCRIPTION
* OSBS-8472

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
