### PR TITLE
user_params: refactor set_params to occur separately of BuildRequest

### DIFF
--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -124,14 +124,14 @@ class BuildCommon(object):
     def KIND(self):
         return 'DEFINE_KIND_NAME_IN_SUBCLASS'
 
-    def __init__(self, build_json_dir=None):
+    def __init__(self, build_json_store=None):
         self.arrangement_version = BuildParam(
             "arrangement_version",
             allow_none=True,
             default=REACTOR_CONFIG_ARRANGEMENT_VERSION)
         self.build_image = BuildParam('build_image')
         self.build_imagestream = BuildParam('build_imagestream')
-        self.build_json_dir = BuildParam('build_json_dir', default=build_json_dir)
+        self.build_json_dir = BuildParam('build_json_dir', default=build_json_store)
         self.kind = BuildParam(KIND_KEY, default=self.KIND)
         self.component = BuildParam('component')
         self.image_tag = BuildParam("image_tag")
@@ -162,36 +162,79 @@ class BuildCommon(object):
                         'Two user params with the same name: {}'.format(param.name))
                 self.convert_dict[param.name] = param
 
-    def set_params(
-        self,
-        build_from=None,
-        build_image=None,
-        build_imagestream=None,
-        component=None,
-        koji_target=None,
-        koji_task_id=None,
-        orchestrator_deadline=None,
-        platform=None,
-        reactor_config_map=None,
-        reactor_config_override=None,
-        scratch=None,
-        signing_intent=None,
-        user=None,
-        worker_deadline=None,
-        **kwargs
-    ):
+    def set_params(self,
+                   build_conf=None,
+                   build_from=None,
+                   build_image=None,
+                   build_imagestream=None,
+                   component=None,
+                   koji_target=None,
+                   koji_task_id=None,
+                   orchestrator_deadline=None,
+                   platform=None,
+                   reactor_config_map=None,
+                   reactor_config_override=None,
+                   scratch=None,
+                   signing_intent=None,
+                   user=None,
+                   worker_deadline=None,
+                   **kwargs):
+        """
+        set parameters in the user parameters.
+
+        these parameters are accepted:
+        :param base_image: str, name of the parent image
+        :param build_conf: BuildConfiguration, the build configuration
+        :param component: str, name of the component
+        :param koji_parent_build: str,
+        :param koji_target: str, koji tag with packages used to build the image
+        :param koji_task_id: str, koji ID
+        :param koji_upload_dir: str, koji directory where the completed image will be uploaded
+        :param platform: str, platform
+        :param reactor_config_override: dict, data structure for reactor config to be injected as
+                                        an environment variable into a worker build;
+                                        when used, reactor_config_map is ignored.
+        :param scratch: bool, build as a scratch build
+        :param signing_intent: bool, True to sign the resulting image
+        :param user: str, name of the user requesting the build
+
+        Please keep the paramater list alphabetized for easier tracking of changes
+
+        the following parameters can be pulled from the BuildConfiguration (ie, build_conf)
+        :param build_image: str,
+        :param build_imagestream: str,
+        :param build_from: str,
+        :param orchestrator_deadline: int, orchestrator deadline in hours
+        :param reactor_config_map: str, name of the config map containing the reactor environment
+        :param worker_deadline: int, worker completion deadline in hours
+        """
+        if build_conf:
+            build_image = build_conf.get_build_image()
+            build_imagestream = build_conf.get_build_imagestream()
+            build_from = build_conf.get_build_from()
+            self.scratch.value = build_conf.get_scratch(scratch)
+            orchestrator_deadline = build_conf.get_orchestor_deadline()
+            worker_deadline = build_conf.get_worker_deadline()
+            reactor_config_map = reactor_config_map or build_conf.get_reactor_config_map()
+        else:
+            self.scratch.value = scratch
+
         self.component.value = component
         self.koji_target.value = koji_target
         self.koji_task_id.value = koji_task_id
         self.platform.value = platform
         self.reactor_config_map.value = reactor_config_map
         self.reactor_config_override.value = reactor_config_override
-        self.scratch.value = scratch
         self.signing_intent.value = signing_intent
         self.user.value = user
 
-        unique_build_args = (build_imagestream, build_image, build_from)
-        if sum(bool(a) for a in unique_build_args) != 1:
+        count = 0
+        for build_arg in (build_imagestream, build_image, build_from):
+            count += 1 if build_arg else 0
+        if count == 0:
+            raise OsbsValidationException(
+                'Please define one of build_from, build_image, build_imagestream')
+        elif count > 1:
             raise OsbsValidationException(
                 'Please only define one of build_from, build_image, build_imagestream')
         self.build_image.value = build_image
@@ -292,9 +335,10 @@ class BuildUserParams(BuildCommon):
 
     KIND = USER_PARAMS_KIND_IMAGE_BUILDS
 
-    def __init__(self, build_json_dir=None, customize_conf=None):
+    def __init__(self, build_json_store=None, customize_conf=None):
         # defines image_tag, koji_target, filesystem_koji_task_id, platform, arrangement_version
-        super(BuildUserParams, self).__init__(build_json_dir=build_json_dir)
+        super(BuildUserParams, self).__init__(build_json_store=build_json_store)
+        self.additional_tags = BuildParam('additional_tags', allow_none=True)
         self.base_image = BuildParam('base_image', allow_none=True)
         self.build_type = BuildParam('build_type')
         self.compose_ids = BuildParam("compose_ids", allow_none=True)
@@ -303,74 +347,173 @@ class BuildUserParams(BuildCommon):
         self.filesystem_koji_task_id = BuildParam("filesystem_koji_task_id", allow_none=True)
         self.flatpak = BuildParam('flatpak', default=False)
         self.git_branch = BuildParam('git_branch')
+        self.git_commit_depth = BuildParam('git_commit_depth', allow_none=True)
         self.git_ref = BuildParam('git_ref', default=DEFAULT_GIT_REF)
         self.git_uri = BuildParam('git_uri')
-        self.remote_source_url = BuildParam('remote_source_url')
-        self.remote_source_build_args = BuildParam('remote_source_build_args')
         self.imagestream_name = BuildParam('imagestream_name')
+        self.is_auto = BuildParam('is_auto', allow_none=True)
         self.isolated = BuildParam('isolated', allow_none=True)
         self.koji_parent_build = BuildParam('koji_parent_build', allow_none=True)
         self.koji_upload_dir = BuildParam('koji_upload_dir', allow_none=True)
-        self.parent_images_digests = BuildParam('parent_images_digests', allow_none=True)
+        self.name = BuildIDParam()
         self.operator_manifests_extract_platform = BuildParam('operator_manifests_extract_platform',
                                                               allow_none=True)
-        self.name = BuildIDParam()
+        self.parent_images_digests = BuildParam('parent_images_digests', allow_none=True)
         self.platforms = BuildParam('platforms', allow_none=True)
         self.release = BuildParam('release', allow_none=True)
-        self.trigger_imagestreamtag = BuildParam('trigger_imagestreamtag')
-        self.yum_repourls = BuildParam("yum_repourls")
+        self.remote_source_build_args = BuildParam('remote_source_build_args', allow_none=True)
+        self.remote_source_url = BuildParam('remote_source_url', allow_none=True)
+        self.skip_build = BuildParam('skip_build', allow_none=True)
         self.tags_from_yaml = BuildParam('tags_from_yaml', allow_none=True)
-        self.additional_tags = BuildParam('additional_tags', allow_none=True)
-        self.git_commit_depth = BuildParam('git_commit_depth', allow_none=True)
+        self.trigger_imagestreamtag = BuildParam('trigger_imagestreamtag')
         self.triggered_after_koji_task = BuildParam('triggered_after_koji_task', allow_none=True)
+        self.yum_repourls = BuildParam("yum_repourls")
+
+        self.auto_build_node_selector = None
+        self.explicit_build_node_selector = None
+        self.isolated_build_node_selector = None
+        self.platform_node_selector = None
+        self.scratch_build_node_selector = None
 
         self.required_params.extend([
             self.build_type,
             self.git_ref,
             self.git_uri,
         ])
+        self.repo_info = None
 
         self.attrs_finalizer()
 
     def set_params(self,
-                   git_uri=None, git_ref=None, git_branch=None,
-                   remote_source_url=None, remote_source_build_args=None,
-                   base_image=None, name_label=None,
-                   release=None,
-                   platforms=None, build_type=None,
+                   additional_tags=None,
+                   base_image=None,
+                   build_conf=None,
+                   build_type=None,
+                   compose_ids=None,
                    filesystem_koji_task_id=None,
-                   koji_parent_build=None, koji_upload_dir=None,
                    flatpak=None,
-                   yum_repourls=None, compose_ids=None,
-                   isolated=None, parent_images_digests=None,
-                   tags_from_yaml=None, additional_tags=None,
+                   git_branch=None,
                    git_commit_depth=None,
+                   git_ref=None,
+                   git_uri=None,
+                   is_auto=None,
+                   isolated=None,
+                   koji_parent_build=None,
+                   koji_upload_dir=None,
+                   name_label=None,
                    operator_manifests_extract_platform=None,
-                   triggered_after_koji_task=None, **kwargs):
-        super(BuildUserParams, self).set_params(**kwargs)
-        self.git_uri.value = git_uri
-        self.git_ref.value = git_ref
+                   auto_build_node_selector=None,
+                   explicit_build_node_selector=None,
+                   isolated_build_node_selector=None,
+                   platform_node_selector=None,
+                   scratch_build_node_selector=None,
+                   parent_images_digests=None,
+                   platform=None,
+                   platforms=None,
+                   release=None,
+                   remote_source_url=None,
+                   remote_source_build_args=None,
+                   repo_info=None,
+                   skip_build=None,
+                   tags_from_yaml=None,
+                   triggered_after_koji_task=None,
+                   yum_repourls=None,
+                   **kwargs):
+        """
+        set parameters in the user parameters. Others are set in the super functions
+
+        these parameters are accepted:
+        :param build_conf: BuildConfiguration, optional build configuration
+        :param build_type: str, orchestrator or worker
+        :param compose_ids: list of int, ODCS composes to use instead of generating new ones
+        :param filesystem_koji_task_id: int, Koji Task that created the base filesystem
+        :param flatpak: if we should build a Flatpak OCI Image
+        :param git_branch: str, branch name of the branch to be pulled
+        :param git_ref: str, commit ID of the branch to be pulled
+        :param git_uri: str, uri of the git repository for the source
+        :param is_auto: bool, build as a automatic build
+        :param isolated: bool, build as an isolated build
+        :param koji_parent_build: str,
+        :param koji_upload_dir: str, koji directory where the completed image will be uploaded
+        :param name_label: str, label of the parent image
+        :param user: str, name of the user requesting the build
+        :param operator_manifests_extract_platform: str, indicates which platform should upload
+                                                    operator manifests to koji
+        :param parent_images_digests: dict, mapping image digests to names and platforms
+        :param platforms: list of str, platforms to build on
+        :param platform: str, platform
+        :param reactor_config_map: str, name of the config map containing the reactor environment
+        :param reactor_config_override: dict, data structure for reactor config to be injected as
+        an environment variable into a worker build;
+        when used, reactor_config_map is ignored.
+        :param release: str,
+
+        :param repo_info: RepoInfo, git repo data for the build
+        :param scratch: bool, build as a scratch build
+        :param signing_intent: bool, True to sign the resulting image
+        :param skip_build: bool, if we should skip build and just set buildconfig for autorebuilds
+        :param triggered_after_koji_task: int, koji task ID from which was autorebuild triggered
+        :param yum_repourls: list of str, uris of the yum repos to pull from
+
+        Please keep the paramater list alphabetized for easier tracking of changes
+
+        the following parameters can be pulled from the BuildConfiguration (ie, build_conf)
+        :param auto_build_node_selector: dict, a nodeselector for auto builds
+        :param explicit_build_node_selector: dict, a nodeselector for explicit builds
+        :param isolated_build_node_selector: dict, a nodeselector for isolated builds
+        :param platform_node_selector: dict, a nodeselector for a user_paramsific platform
+        :param scratch_build_node_selector: dict, a nodeselector for scratch builds
+
+        the following parameters can be pulled from the RepoInfo (ie, repo_info)
+        :param git_branch: str, branch name of the branch to be pulled
+        :param git_ref: str, commit ID of the branch to be pulled
+        :param git_uri: str, uri of the git repository for the source
+        """
+        super(BuildUserParams, self).set_params(build_conf=build_conf, platform=platform,
+                                                **kwargs)
+        if repo_info:
+            additional_tags = repo_info.additional_tags.tags
+            git_branch = repo_info.git_branch
+            git_commit_depth = repo_info.git_commit_depth
+            git_ref = repo_info.git_ref
+            git_uri = repo_info.git_uri
+            tags_from_yaml = repo_info.additional_tags.from_container_yaml
+            self.repo_info = repo_info
+        elif not git_uri:
+            raise OsbsValidationException('no repo_info passed to BuildUserParams')
+
+        if build_conf:
+            auto_build_node_selector = build_conf.get_auto_build_node_selector()
+            explicit_build_node_selector = build_conf.get_explicit_build_node_selector()
+            isolated_build_node_selector = build_conf.get_isolated_build_node_selector()
+            platform_node_selector = build_conf.get_platform_node_selector(platform)
+            scratch_build_node_selector = build_conf.get_scratch_build_node_selector()
+
+        self.additional_tags.value = additional_tags or set()
         self.git_branch.value = git_branch
+        self.git_commit_depth.value = git_commit_depth
+        self.git_ref.value = git_ref
+        self.git_uri.value = git_uri
+
         self.remote_source_url.value = remote_source_url
         self.remote_source_build_args.value = remote_source_build_args
-        self.git_commit_depth.value = git_commit_depth
-        self.tags_from_yaml.value = tags_from_yaml
-        self.additional_tags.value = additional_tags or set()
-
         self.release.value = release
         self.build_type.value = build_type
         self.base_image.value = base_image
 
         self.name.value = make_name_from_git(self.git_uri.value, self.git_branch.value)
 
-        self.parent_images_digests.value = parent_images_digests
-        self.operator_manifests_extract_platform.value = operator_manifests_extract_platform
-        self.platforms.value = platforms
         self.filesystem_koji_task_id.value = filesystem_koji_task_id
+        self.is_auto.value = is_auto
+        self.isolated.value = isolated
+        self.flatpak.value = flatpak
         self.koji_parent_build.value = koji_parent_build
         self.koji_upload_dir.value = koji_upload_dir
-        self.flatpak.value = flatpak
-        self.isolated.value = isolated
+        self.parent_images_digests.value = parent_images_digests
+        self.platforms.value = platforms
+        self.operator_manifests_extract_platform.value = operator_manifests_extract_platform
+        self.skip_build.value = skip_build
+        self.tags_from_yaml.value = tags_from_yaml
         self.triggered_after_koji_task.value = triggered_after_koji_task
 
         if not flatpak:
@@ -389,8 +532,18 @@ class BuildUserParams(BuildCommon):
             raise OsbsValidationException("compose_ids must be a list")
         if not (yum_repourls is None or isinstance(yum_repourls, list)):
             raise OsbsValidationException("yum_repourls must be a list")
-        self.yum_repourls.value = yum_repourls or []
         self.compose_ids.value = compose_ids or []
+        self.yum_repourls.value = yum_repourls or []
+
+        if (self.scratch.value, self.is_auto.value, self.isolated.value).count(True) > 1:
+            raise OsbsValidationException(
+                'Build variations are mutually exclusive. '
+                'Must set either scratch, is_auto, isolated, or none. ')
+        self.auto_build_node_selector = auto_build_node_selector or {}
+        self.explicit_build_node_selector = explicit_build_node_selector or {}
+        self.isolated_build_node_selector = isolated_build_node_selector or {}
+        self.platform_node_selector = platform_node_selector or {}
+        self.scratch_build_node_selector = scratch_build_node_selector or {}
 
 
 @register_user_params
@@ -399,9 +552,8 @@ class SourceContainerUserParams(BuildCommon):
 
     KIND = USER_PARAMS_KIND_SOURCE_CONTAINER_BUILDS
 
-    def __init__(self, build_json_dir=None):
-        super(SourceContainerUserParams, self).__init__(
-            build_json_dir=build_json_dir)
+    def __init__(self, build_json_store=None):
+        super(SourceContainerUserParams, self).__init__(build_json_store=build_json_store)
         self.sources_for_koji_build_nvr = BuildParam("sources_for_koji_build_nvr", allow_none=True)
         self.sources_for_koji_build_id = BuildParam("sources_for_koji_build_id", allow_none=True)
 

--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -35,6 +35,22 @@ class RepoInfo(object):
         self.additional_tags = additional_tags or AdditionalTagsConfig(
             tags=self.configuration.container.get('tags', set()))
 
+    @property
+    def git_branch(self):
+        return self.configuration.git_branch
+
+    @property
+    def git_ref(self):
+        return self.configuration.git_ref
+
+    @property
+    def git_uri(self):
+        return self.configuration.git_uri
+
+    @property
+    def git_commit_depth(self):
+        return self.configuration.depth
+
 
 class RepoConfiguration(object):
     """
@@ -46,12 +62,16 @@ class RepoConfiguration(object):
         enabled = false
         """)
 
-    def __init__(self, dir_path='', file_name=REPO_CONFIG_FILE, depth=None):
-
+    def __init__(self, dir_path='', file_name=REPO_CONFIG_FILE, depth=None,
+                 git_uri=None, git_branch=None, git_ref=None):
         self._config_parser = ConfigParser()
         self.container = {}
         self.depth = depth or 0
         self.autorebuild = {}
+        # Keep track of the repo metadata in the repo configuration
+        self.git_uri = git_uri
+        self.git_branch = git_branch
+        self.git_ref = git_ref
 
         # Set default options
         self._config_parser.readfp(StringIO(self.DEFAULT_CONFIG))   # pylint: disable=W1505; py2

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -350,10 +350,12 @@ def get_repo_info(git_uri, git_ref, git_branch=None, depth=None):
         code_dir = code_dir_info.repo_path
         depth = code_dir_info.commit_depth
         dfp = DockerfileParser(os.path.join(code_dir), cache_content=True)
-        config = RepoConfiguration(dir_path=code_dir, depth=depth)
+        config = RepoConfiguration(git_uri=git_uri, git_ref=git_ref, git_branch=git_branch,
+                                   dir_path=code_dir, depth=depth)
         tags_config = AdditionalTagsConfig(dir_path=code_dir,
                                            tags=config.container.get('tags', set()))
-    return RepoInfo(dfp, config, tags_config)
+    repo_info = RepoInfo(dfp, config, tags_config)
+    return repo_info
 
 
 def git_repo_humanish_part_from_uri(git_uri):

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -75,6 +75,8 @@ def get_sample_source_container_params():
         "platform": "x86_64",
         'user': TEST_USER,
         "sources_for_koji_build_nvr": "test-1-123",
+        "sources_for_koji_build_id": 12345,
+        "signing_intent": "release",
     }
 
 


### PR DESCRIPTION
user_params: refactor set_params to occur separately of BuildRequest
    
part of OSBS-8220
    
Create and populate the BuildUserParams before creating the BuildRequest,
and use the BuildUserParams exclusively as the data store within
BuildRequest.
    
Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

# TODO
- [x] Complete unit tests
- [x] ~~Refactor for submission~~ I hate submitting this as one big change, but there's no way to break it up.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
