### PR TITLE
run add_buildargs_in_dockerfile plugin in worker

### DIFF
--- a/inputs/worker_inner:6.json
+++ b/inputs/worker_inner:6.json
@@ -56,6 +56,9 @@
     },
     {
       "name": "download_remote_source"
+    },
+    {
+      "name": "add_buildargs_in_dockerfile"
     }
   ],
   "prepublish_plugins": [

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -332,6 +332,7 @@ class TestArrangementV6(ArrangementBase):
                 'inject_yum_repo',
                 'distribution_scope',
                 'download_remote_source',
+                'add_buildargs_in_dockerfile'
             ],
 
             'buildstep_plugins': [


### PR DESCRIPTION
* OSBS-8515

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
