### PR TITLE
properties in build_request for base_image and triggered_after_koji_task

### DIFF
--- a/osbs/build/build_requestv2.py
+++ b/osbs/build/build_requestv2.py
@@ -353,6 +353,14 @@ class BuildRequestV2(BaseBuildRequest):
     def skip_build(self):
         return self.user_params.skip_build.value
 
+    @property
+    def triggered_after_koji_task(self):
+        return self.user_params.triggered_after_koji_task.value
+
+    @property
+    def base_image(self):
+        return self.user_params.base_image.value
+
     # Override
     @property
     def trigger_imagestreamtag(self):

--- a/tests/build_/test_build_requestv2.py
+++ b/tests/build_/test_build_requestv2.py
@@ -195,6 +195,8 @@ class TestBuildRequestV2(object):
         build_json = build_request.render()
 
         assert build_request.user_params.triggered_after_koji_task.value == trigger_after_koji_task
+        assert build_request.triggered_after_koji_task == trigger_after_koji_task
+        assert build_request.base_image == user_params.base_image.value
 
         assert build_json["metadata"]["name"] is not None
         assert "triggers" not in build_json["spec"]


### PR DESCRIPTION
OSBS-8220

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
