### PR TITLE
Add the add_flatpak_labels plugin

### DIFF
--- a/inputs/orchestrator_inner:6.json
+++ b/inputs/orchestrator_inner:6.json
@@ -40,6 +40,9 @@
       "name": "bump_release"
     },
     {
+      "name": "add_flatpak_labels"
+    },
+    {
       "name": "add_labels_in_dockerfile"
     },
     {

--- a/inputs/worker_inner:6.json
+++ b/inputs/worker_inner:6.json
@@ -22,6 +22,9 @@
       }
     },
     {
+      "name": "add_flatpak_labels"
+    },
+    {
       "name": "add_labels_in_dockerfile"
     },
     {

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -252,6 +252,15 @@ class PluginsConfigurationBase(object):
             self.pt.set_plugin_arg_valid(phase, plugin, 'koji_target',
                                          self.user_params.koji_target.value)
 
+    def render_add_flatpak_labels(self):
+        phase = 'prebuild_plugins'
+        plugin = 'add_flatpak_labels'
+
+        if self.pt.has_plugin_conf(phase, plugin):
+            if not self.user_params.flatpak.value:
+                self.pt.remove_plugin(phase, plugin)
+                return
+
     def render_add_labels_in_dockerfile(self):
         phase = 'prebuild_plugins'
         plugin = 'add_labels_in_dockerfile'
@@ -603,6 +612,7 @@ class PluginsConfiguration(PluginsConfigurationBase):
 
         # Set parameters on each plugin as needed
         self.render_add_filesystem()
+        self.render_add_flatpak_labels()
         self.render_add_labels_in_dockerfile()
         self.render_add_yum_repo_by_url()
         self.render_bump_release()

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -283,6 +283,7 @@ class TestArrangementV6(ArrangementBase):
                 'inject_parent_image',
                 'pull_base_image',
                 'bump_release',
+                'add_flatpak_labels',
                 'add_labels_in_dockerfile',
                 PLUGIN_KOJI_PARENT_KEY,
                 PLUGIN_RESOLVE_COMPOSES_KEY,
@@ -326,6 +327,7 @@ class TestArrangementV6(ArrangementBase):
                 PLUGIN_ADD_FILESYSTEM_KEY,
                 'inject_parent_image',
                 'pull_base_image',
+                'add_flatpak_labels',
                 'add_labels_in_dockerfile',
                 'change_from_in_dockerfile',
                 'add_help',
@@ -746,6 +748,8 @@ class TestArrangementV6(ArrangementBase):
 
         with pytest.raises(KeyError):
             plugin_value_get(plugins, 'prebuild_plugins', 'flatpak_create_dockerfile', 'args')
+        with pytest.raises(KeyError):
+            plugin_value_get(plugins, 'prebuild_plugins', 'add_flatpak_labels', 'args')
 
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "import_image")
@@ -767,6 +771,8 @@ class TestArrangementV6(ArrangementBase):
             get_plugin(plugins, "prebuild_plugins", "resolve_module_compose")
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "prebuild_plugins", "flatpak_create_dockerfile")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "prebuild_plugins", "add_flatpak_labels")
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "prepublish_plugins", "flatpak_create_oci")
 

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -268,6 +268,7 @@ class TestPluginsConfiguration(object):
     flatpak_plugins = [
         ("ow", "prebuild_plugins", "resolve_module_compose"),
         ("ow", "prebuild_plugins", "flatpak_create_dockerfile"),
+        ("ow", "prebuild_plugins", "add_flatpak_labels"),
         ("w", "prepublish_plugins", "flatpak_create_oci"),
     ]
 
@@ -333,6 +334,8 @@ class TestPluginsConfiguration(object):
             assert args['signing_intent'] == signing_intent
 
         plugin = get_plugin(plugins, "prebuild_plugins", "flatpak_create_dockerfile")
+        assert plugin
+        plugin = get_plugin(plugins, "prebuild_plugins", "add_flatpak_labels")
         assert plugin
 
         if build_type == BUILD_TYPE_ORCHESTRATOR:


### PR DESCRIPTION
Add the add_flatpak_labels plugin, which adds labels from container.yaml
into the generated Dockerfile.

See https://github.com/containerbuildsystem/atomic-reactor/pull/1371

Signed-off-by: Owen W. Taylor <otaylor@fishsoup.net>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
