### PR TITLE
user_params: minor clean-ups after the big refactor

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -220,10 +220,10 @@ class OSBS(object):
                                               storage=storage_limit)
 
     @osbsapi
-    def get_build_request(self, build_type=None, inner_template=None,
+    def get_build_request(self, inner_template=None,
                           outer_template=None, customize_conf=None,
                           arrangement_version=DEFAULT_ARRANGEMENT_VERSION,
-                          user_params=None,
+                          user_params=None, **kwargs
                           ):
         """
         return instance of BuildRequestV2
@@ -236,9 +236,6 @@ class OSBS(object):
 
         :return: instance of BuildRequestV2
         """
-        if build_type is not None:
-            warnings.warn("build types are deprecated, do not use the build_type argument")
-
         validate_arrangement_version(arrangement_version)
 
         build_request = BuildRequestV2(

--- a/osbs/build/build_requestv2.py
+++ b/osbs/build/build_requestv2.py
@@ -101,11 +101,9 @@ class BaseBuildRequest(object):
     def render_custom_strategy(self):
         """Render data about buildroot used for custom strategy"""
         custom_strategy = self.template['spec']['strategy']['customStrategy']
-        if self.user_params.build_imagestream.value:
+        if self.user_params.buildroot_is_imagestream.value:
             custom_strategy['from']['kind'] = 'ImageStreamTag'
-            custom_strategy['from']['name'] = self.user_params.build_imagestream.value
-        else:
-            custom_strategy['from']['name'] = self.user_params.build_image.value
+        custom_strategy['from']['name'] = self.user_params.build_image.value
 
     def render_name(self):
         """Sets the Build/BuildConfig object name"""

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -482,7 +482,7 @@ class PluginsConfigurationBase(object):
 
         config_kwargs = {}
 
-        if not self.user_params.build_imagestream.value:
+        if not self.user_params.buildroot_is_imagestream.value:
             config_kwargs['build_from'] = 'image:' + self.user_params.build_image.value
 
         self.pt.set_plugin_arg(phase, plugin, 'config_kwargs', config_kwargs)

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -483,7 +483,7 @@ class PluginsConfigurationBase(object):
         config_kwargs = {}
 
         if not self.user_params.build_imagestream.value:
-            config_kwargs['build_image'] = self.user_params.build_image.value
+            config_kwargs['build_from'] = 'image:' + self.user_params.build_image.value
 
         self.pt.set_plugin_arg(phase, plugin, 'config_kwargs', config_kwargs)
 

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -168,14 +168,11 @@ class BuildCommon(object):
                    component=None,
                    koji_target=None,
                    koji_task_id=None,
-                   orchestrator_deadline=None,
                    platform=None,
-                   reactor_config_map=None,
                    reactor_config_override=None,
                    scratch=None,
                    signing_intent=None,
                    user=None,
-                   worker_deadline=None,
                    **kwargs):
         """
         set parameters in the user parameters.
@@ -198,26 +195,25 @@ class BuildCommon(object):
 
         Please keep the paramater list alphabetized for easier tracking of changes
 
-        the following parameters can be pulled from the BuildConfiguration (ie, build_conf)
+        the following parameters are pulled from the BuildConfiguration (ie, build_conf)
         :param build_from: str,
         :param orchestrator_deadline: int, orchestrator deadline in hours
         :param reactor_config_map: str, name of the config map containing the reactor environment
         :param worker_deadline: int, worker completion deadline in hours
         """
-        if build_conf:
-            build_from = build_from or build_conf.get_build_from()
-            self.scratch.value = build_conf.get_scratch(scratch)
-            orchestrator_deadline = build_conf.get_orchestor_deadline()
-            worker_deadline = build_conf.get_worker_deadline()
-            reactor_config_map = reactor_config_map or build_conf.get_reactor_config_map()
-        else:
-            self.scratch.value = scratch
+        if not build_conf:
+            raise OsbsValidationException('build_conf must be defined')
+
+        build_from = build_from or build_conf.get_build_from()
+        self.scratch.value = build_conf.get_scratch(scratch)
+        orchestrator_deadline = build_conf.get_orchestor_deadline()
+        worker_deadline = build_conf.get_worker_deadline()
 
         self.component.value = component
         self.koji_target.value = koji_target
         self.koji_task_id.value = koji_task_id
         self.platform.value = platform
-        self.reactor_config_map.value = reactor_config_map
+        self.reactor_config_map.value = build_conf.get_reactor_config_map()
         self.reactor_config_override.value = reactor_config_override
         self.signing_intent.value = signing_intent
         self.user.value = user
@@ -448,7 +444,7 @@ class BuildUserParams(BuildCommon):
 
         Please keep the paramater list alphabetized for easier tracking of changes
 
-        the following parameters can be pulled from the BuildConfiguration (ie, build_conf)
+        the following parameters are pulled from the BuildConfiguration (ie, build_conf)
         :param auto_build_node_selector: dict, a nodeselector for auto builds
         :param explicit_build_node_selector: dict, a nodeselector for explicit builds
         :param isolated_build_node_selector: dict, a nodeselector for isolated builds
@@ -473,12 +469,11 @@ class BuildUserParams(BuildCommon):
         elif not git_uri:
             raise OsbsValidationException('no repo_info passed to BuildUserParams')
 
-        if build_conf:
-            auto_build_node_selector = build_conf.get_auto_build_node_selector()
-            explicit_build_node_selector = build_conf.get_explicit_build_node_selector()
-            isolated_build_node_selector = build_conf.get_isolated_build_node_selector()
-            platform_node_selector = build_conf.get_platform_node_selector(platform)
-            scratch_build_node_selector = build_conf.get_scratch_build_node_selector()
+        auto_build_node_selector = build_conf.get_auto_build_node_selector()
+        explicit_build_node_selector = build_conf.get_explicit_build_node_selector()
+        isolated_build_node_selector = build_conf.get_isolated_build_node_selector()
+        platform_node_selector = build_conf.get_platform_node_selector(platform)
+        scratch_build_node_selector = build_conf.get_scratch_build_node_selector()
 
         self.additional_tags.value = additional_tags or set()
         self.git_branch.value = git_branch

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -129,8 +129,12 @@ class BuildCommon(object):
             "arrangement_version",
             allow_none=True,
             default=REACTOR_CONFIG_ARRANGEMENT_VERSION)
+        # build_from contains the full build_from string, including the source type prefix
+        self.build_from = BuildParam('build_from')
+        # build_image contains the buildroot name, whether the buildroot is a straight image or an
+        # imagestream.  buildroot_is_imagestream indicates what type of buildroot
         self.build_image = BuildParam('build_image')
-        self.build_imagestream = BuildParam('build_imagestream')
+        self.buildroot_is_imagestream = BuildParam('buildroot_is_imagestream', default=False)
         self.build_json_dir = BuildParam('build_json_dir', default=build_json_store)
         self.kind = BuildParam(KIND_KEY, default=self.KIND)
         self.component = BuildParam('component')
@@ -227,10 +231,10 @@ class BuildCommon(object):
         if source_type not in ('image', 'imagestream'):
             raise OsbsValidationException(
                 'first part in build_from, may be only image or imagestream')
-        if source_type == 'image':
-            self.build_image.value = source_value
-        else:
-            self.build_imagestream.value = source_value
+        if source_type == 'imagestream':
+            self.buildroot_is_imagestream.value = True
+        self.build_from.value = build_from
+        self.build_image.value = source_value
 
         try:
             self.orchestrator_deadline.value = int(orchestrator_deadline)

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -264,12 +264,6 @@ class Configuration(object):
     def get_storage_limit(self):
         return self._get_value("storage_limit", self.conf_section, "storage_limit")
 
-    def get_build_image(self):
-        return self._get_value("build_image", self.conf_section, "build_image")
-
-    def get_build_imagestream(self):
-        return self._get_value("build_imagestream", self.conf_section, "build_imagestream")
-
     def get_build_from(self):
         return self._get_value("build_from", self.conf_section, "build_from")
 

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -135,11 +135,13 @@ class Configuration(object):
         """
         deprecated_key = "openshift_uri"
         key = "openshift_url"
+        val = self._get_value(key, self.conf_section, key)
+        if val:
+            return val
         val = self._get_value(deprecated_key, self.conf_section, deprecated_key)
         if val is not None:
             warnings.warn("%r is deprecated, use %r instead" % (deprecated_key, key))
-            return val
-        return self._get_value(key, self.conf_section, key)
+        return val
 
     @staticmethod
     def get_k8s_api_version():

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -16,6 +16,7 @@ from osbs.constants import (DEFAULT_ARRANGEMENT_VERSION,
                             WORKER_INNER_TEMPLATE,
                             ORCHESTRATOR_OUTER_TEMPLATE)
 from osbs import utils
+from osbs.conf import Configuration
 from osbs.repo_utils import RepoInfo, ModuleSpec
 from osbs.build.build_requestv2 import BuildRequestV2
 from osbs.build.plugins_configuration import PluginsConfiguration
@@ -207,6 +208,8 @@ class ArrangementBase(object):
 
         params.update(additional_params or {})
         params['arrangement_version'] = self.ARRANGEMENT_VERSION
+        osbs.build_conf = osbs.build_conf or Configuration(params)
+
         return params, fn(**params).json
 
     def get_orchestrator_build_request(self, osbs,  # noqa:F811
@@ -253,7 +256,7 @@ class TestArrangementV6(ArrangementBase):
         'git_ref': TEST_GIT_REF,
         'git_branch': TEST_GIT_BRANCH,
         'user': 'john-foo',
-        'build_image': 'test',
+        'build_from': 'image:test',
         'reactor_config_map': 'special-config',
     }
 
@@ -377,7 +380,7 @@ class TestArrangementV6(ArrangementBase):
             'git_branch': TEST_GIT_BRANCH,
             'user': 'john-foo',
             'build_type': template.split('_')[0],
-            'build_image': 'test',
+            'build_from': 'image:test',
             'base_image': 'test',
             'name_label': 'test',
         }

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -374,13 +374,17 @@ class TestArrangementV6(ArrangementBase):
 
     # override
     def get_plugins_from_buildrequest(self, build_request, template):
+        conf_kwargs = {
+           'build_from': 'image:test',
+           'reactor_config_map': 'reactor-config-map',
+        }
         kwargs = {
             'git_uri': TEST_GIT_URI,
             'git_ref': TEST_GIT_REF,
             'git_branch': TEST_GIT_BRANCH,
             'user': 'john-foo',
             'build_type': template.split('_')[0],
-            'build_from': 'image:test',
+            'build_conf': Configuration(conf_file=None, **conf_kwargs),
             'base_image': 'test',
             'name_label': 'test',
         }
@@ -406,12 +410,6 @@ class TestArrangementV6(ArrangementBase):
                 break
         else:
             raise KeyError('USER_PARAMS not set in env')
-
-        for entry in env:
-            if entry['name'] == 'REACTOR_CONFIG':
-                break
-        else:
-            raise KeyError('REACTOR_CONFIG not set in env')
 
         plugins_json = osbs.render_plugins_configuration(user_params)
         for entry in env:

--- a/tests/build_/test_build_requestv2.py
+++ b/tests/build_/test_build_requestv2.py
@@ -185,12 +185,15 @@ class TestBuildRequestV2(object):
 
     def test_render_simple_request(self):
         trigger_after_koji_task = '12345'
-        extra_kwargs = {
+        conf_args = {
+            'build_from': 'image:buildroot:latest',
             'reactor_config_map': 'reactor-config-map',
+        }
+        extra_kwargs = {
             'triggered_after_koji_task': trigger_after_koji_task,
         }
 
-        user_params = get_sample_user_params(update_args=extra_kwargs)
+        user_params = get_sample_user_params(conf_args=conf_args, update_args=extra_kwargs)
         build_request = BuildRequestV2(osbs_api=MockOSBSApi(), user_params=user_params)
         build_json = build_request.render()
 
@@ -685,12 +688,15 @@ class TestBuildRequestV2(object):
         if build_type == BUILD_TYPE_ORCHESTRATOR:
             outer_template = ORCHESTRATOR_OUTER_TEMPLATE
 
-        update_args = {
+        conf_args = {
+            'build_from': 'image:buildroot:latest',
             'reactor_config_map': reactor_config_map,
+        }
+        update_args = {
             'reactor_config_override': reactor_config_override,
             'build_type': build_type,
         }
-        user_params = get_sample_user_params(update_args=update_args)
+        user_params = get_sample_user_params(conf_args=conf_args, update_args=update_args)
         build_request = BuildRequestV2(osbs_api=MockOSBSApi(), user_params=user_params,
                                        outer_template=outer_template)
         build_json = build_request.render()
@@ -765,12 +771,15 @@ class TestBuildRequestV2(object):
         if build_type == BUILD_TYPE_ORCHESTRATOR:
             outer_template = ORCHESTRATOR_OUTER_TEMPLATE
 
-        update_args = {
+        conf_args = {
+            'build_from': 'image:buildroot:latest',
             'reactor_config_map': reactor_config_map,
+        }
+        update_args = {
             'reactor_config_override': reactor_config_override,
             'build_type': build_type,
         }
-        user_params = get_sample_user_params(update_args=update_args)
+        user_params = get_sample_user_params(conf_args=conf_args, update_args=update_args)
 
         all_secrets = deepcopy(reactor_config_map)
         mock_api = MockOSBSApi(all_secrets)
@@ -846,13 +855,16 @@ class TestBuildRequestV2(object):
         if build_type == BUILD_TYPE_ORCHESTRATOR:
             outer_template = ORCHESTRATOR_OUTER_TEMPLATE
 
-        update_args = {
+        conf_args = {
+            'build_from': 'image:buildroot:latest',
             'reactor_config_map': reactor_config_map,
+        }
+        update_args = {
             'reactor_config_override': reactor_config_override,
             'build_type': build_type,
             'flatpak': flatpak,
         }
-        user_params = get_sample_user_params(update_args=update_args)
+        user_params = get_sample_user_params(conf_args=conf_args, update_args=update_args)
 
         all_secrets = deepcopy(reactor_config_map)
         mock_api = MockOSBSApi(all_secrets)
@@ -982,6 +994,7 @@ def get_sample_source_params(build_json_store=INPUTS_PATH, conf_args=None,
     # scratch handling is tricky
     if update_args:
         conf_args.setdefault('scratch', update_args.get('scratch'))
+    conf_args.setdefault('reactor_config_map', 'reactor-config-map')
 
     user_params = SourceContainerUserParams(build_json_store)
 
@@ -996,7 +1009,6 @@ def get_sample_source_params(build_json_store=INPUTS_PATH, conf_args=None,
         'filesystem_koji_task_id': TEST_FILESYSTEM_KOJI_TASK_ID,
         'build_conf': build_conf,
         'build_type': BUILD_TYPE_WORKER,
-        'reactor_config_map': 'reactor-config-map',
         'sources_for_koji_build_nvr': "name-1.0-123",
     }
     if update_args:

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -231,8 +231,8 @@ class TestBuildUserParams(object):
         repo_conf = RepoConfiguration(git_branch=TEST_GIT_BRANCH, git_ref=TEST_GIT_REF,
                                       git_uri=TEST_GIT_URI)
         repo_info = RepoInfo(configuration=repo_conf)
-        build_conf = Configuration(build_from='image:buildroot:latest', orchestrator_deadline=4,
-                                   scratch=False, worker_deadline=3)
+        build_conf = Configuration(conf_file=None, build_from='image:buildroot:latest',
+                                   orchestrator_deadline=4, scratch=False, worker_deadline=3)
 
         # all values that BuildUserParams stores
         param_kwargs = {
@@ -259,7 +259,7 @@ class TestBuildUserParams(object):
             'operator_bundle_replacement_pullspecs': {
                 'foo/fedora:30': 'bar/fedora@sha256:deadbeef'
             },
-            # "orchestrator_deadline": 4,
+            # "orchestrator_deadline": 4,  # set in config
             'parent_images_digests': {
                 'registry.fedorahosted.org/fedora:29': {
                     'x86_64': 'registry.fedorahosted.org/fedora@sha256:8b96f2f9f88179a065738b2b37'
@@ -269,16 +269,16 @@ class TestBuildUserParams(object):
             # 'name': self.name,  # calculated value
             'platform': 'x86_64',
             'platforms': ['x86_64', ],
-            'reactor_config_map': 'reactor-config-map',
+            # 'reactor_config_map': 'reactor-config-map',  # set in config
             'reactor_config_override': 'reactor-config-override',
             'release': '29',
-            # 'scratch': False,
+            # 'scratch': True,  # set in config
             'signing_intent': False,
             'task_id': TEST_KOJI_TASK_ID,
             # 'trigger_imagestreamtag': 'base_image:latest',  # generated from base_image
             'user': TEST_USER,
             # 'yum_repourls': ,  # not used with compose_ids
-            # "worker_deadline": 3,
+            # "worker_deadline": 3,  # set in config
         }
         # additional values that BuildUserParams requires but stores under different names
         param_kwargs.update({
@@ -332,7 +332,6 @@ class TestBuildUserParams(object):
             },
             "platform": "x86_64",
             "platforms": ["x86_64"],
-            "reactor_config_map": "reactor-config-map",
             "reactor_config_override": "reactor-config-override",
             "release": "29",
             "trigger_imagestreamtag": "buildroot:old",

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -303,6 +303,7 @@ class TestBuildUserParams(object):
         expected_json = {
             "arrangement_version": REACTOR_CONFIG_ARRANGEMENT_VERSION,
             "base_image": "buildroot:old",
+            "build_from": "image:buildroot:latest",
             "build_image": "buildroot:latest",
             "build_json_dir": build_json_dir,
             "build_type": "worker",
@@ -448,6 +449,7 @@ class TestSourceContainerUserParams(object):
 
         expected_json = {
             "arrangement_version": REACTOR_CONFIG_ARRANGEMENT_VERSION,
+            "build_from": "image:buildroot:latest",
             "build_image": "buildroot:latest",
             "build_json_dir": build_json_dir,
             'component': TEST_COMPONENT,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -224,12 +224,11 @@ class TestOSBS(object):
             .and_return(self.mock_repo_info()))
 
         kwargs = {
-            'git_uri': TEST_GIT_URI,
+            'git_url': TEST_GIT_URI,
             'git_ref': TEST_GIT_REF,
             'git_branch': TEST_GIT_BRANCH,
             'user': TEST_USER,
             'target': TEST_TARGET,
-            'build_type': BUILD_TYPE_ORCHESTRATOR,
             'yum_repourls': None,
             'koji_task_id': None,
             'scratch': False,
@@ -299,6 +298,7 @@ class TestOSBS(object):
 
         user_params = BuildUserParams(build_json_store=osbs.os_conf.get_build_json_store())
         user_params.set_params(base_image='fedora23/python', build_from='image:whatever',
+                               build_conf=osbs.build_conf,
                                name_label='whatever', repo_info=repo_info, **REQUIRED_BUILD_ARGS)
 
         (flexmock(utils)
@@ -1731,6 +1731,7 @@ class TestOSBS(object):
             user='user',
             # for build request v1
             base_image='old_registry.com/fedora23/python',
+            build_conf=osbs_obj.build_conf,
             name_label='name_label',
             git_uri='https://github.com/user/reponame.git',
             build_from='image:buildroot:latest',
@@ -2642,6 +2643,7 @@ class TestOSBS(object):
 
         user_params = BuildUserParams(build_json_store=osbs.os_conf.get_build_json_store())
         user_params.set_params(base_image='fedora23/python', build_from='image:whatever',
+                               build_conf=osbs.build_conf,
                                name_label='whatever', repo_info=repo_info, user=TEST_USER,
                                build_type=BUILD_TYPE_ORCHESTRATOR,
                                skip_build=skip_build)
@@ -2833,6 +2835,7 @@ class TestOSBS(object):
         spec.set_params(
             user='user',
             base_image='fedora23/python',
+            build_conf=osbs_obj.build_conf,
             name_label='name_label',
             git_uri='https://github.com/user/reponame.git',
             build_from='image:buildroot:latest',
@@ -2980,6 +2983,7 @@ class TestOSBS(object):
             name_label='name_label',
             git_uri='https://github.com/user/reponame.git',
             build_from='image:buildroot:latest',
+            build_conf=osbs_obj.build_conf,
         )
 
         build_request = flexmock(
@@ -3094,6 +3098,7 @@ class TestOSBS(object):
 
         user_params = BuildUserParams(build_json_store=osbs.os_conf.get_build_json_store())
         user_params.set_params(base_image='scratch', build_from='image:python',
+                               build_conf=osbs.build_conf,
                                name_label='scratch', repo_info=repo_info, user=TEST_USER,
                                isolated=True, build_type=BUILD_TYPE_ORCHESTRATOR, release='0.1')
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -224,7 +224,7 @@ class TestOSBS(object):
             .and_return(self.mock_repo_info()))
 
         kwargs = {
-            'git_url': TEST_GIT_URI,
+            'git_uri': TEST_GIT_URI,
             'git_ref': TEST_GIT_REF,
             'git_branch': TEST_GIT_BRANCH,
             'user': TEST_USER,
@@ -232,6 +232,7 @@ class TestOSBS(object):
             'yum_repourls': None,
             'koji_task_id': None,
             'scratch': False,
+            'build_type': BUILD_TYPE_ORCHESTRATOR,
             # Stuff that should be ignored and not cause erros
             'labels': {'Release': 'bacon'},
             'spam': 'maps',

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -23,7 +23,7 @@ def test_missing_config():
 
 
 def test_no_config():
-    os_conf = Configuration(conf_file=None, openshift_uri='https://example:8443')
+    os_conf = Configuration(conf_file=None, openshift_url='https://example:8443')
     assert os_conf.get_openshift_oauth_api_uri() == 'https://example:8443/oauth/authorize'
 
 
@@ -52,7 +52,7 @@ def test_no_inputs():
 build_json_dir=/nonexistent/path/
 
 [default]
-openshift_uri=https://172.0.0.1:8443/
+openshift_url=https://172.0.0.1:8443/
 registry_uri=127.0.0.1:5000
 """)
         f.flush()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -42,7 +42,7 @@ build_host=localhost
         f.seek(0)
         os_conf = Configuration(conf_file=f.name,
                                 conf_section="default")
-        assert os_conf.get_build_image() is None
+        assert os_conf.get_build_from() is None
 
 
 def test_no_inputs():


### PR DESCRIPTION
Part of OSBS-8220

Fix some minor issues related to #928: build_conf is required for set_params (and some unit tests are restructured accordingly) and only build_from is a valid way to specify the build image or build imagestream.

Requires atomic reactor changes from [PR-1931](https://github.com/containerbuildsystem/atomic-reactor/pull/1391)

Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
