### PR TITLE
Adjust the pre-build Flatpak plugins

### DIFF
--- a/inputs/orchestrator_inner:6.json
+++ b/inputs/orchestrator_inner:6.json
@@ -18,9 +18,6 @@
       "required": false
     },
     {
-      "name": "resolve_module_compose"
-    },
-    {
       "name": "flatpak_create_dockerfile"
     },
     {
@@ -41,6 +38,9 @@
     },
     {
       "name": "resolve_composes"
+    },
+    {
+      "name": "flatpak_update_dockerfile"
     },
     {
       "name": "bump_release"

--- a/inputs/orchestrator_inner:6.json
+++ b/inputs/orchestrator_inner:6.json
@@ -37,6 +37,12 @@
       }
     },
     {
+      "name": "koji_parent"
+    },
+    {
+      "name": "resolve_composes"
+    },
+    {
       "name": "bump_release"
     },
     {
@@ -44,12 +50,6 @@
     },
     {
       "name": "add_labels_in_dockerfile"
-    },
-    {
-      "name": "koji_parent"
-    },
-    {
-      "name": "resolve_composes"
     },
     {
       "name": "resolve_remote_source"

--- a/inputs/worker_inner:6.json
+++ b/inputs/worker_inner:6.json
@@ -4,10 +4,10 @@
       "name": "reactor_config"
     },
     {
-      "name": "resolve_module_compose"
+      "name": "flatpak_create_dockerfile"
     },
     {
-      "name": "flatpak_create_dockerfile"
+      "name": "flatpak_update_dockerfile"
     },
     {
       "name": "add_filesystem"

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -230,7 +230,6 @@ class PluginsConfigurationBase(object):
         """
         if self.user_params.flatpak.value:
             remove_plugins = [
-                ("prebuild_plugins", "resolve_composes"),
                 # We'll extract the filesystem anyways for a Flatpak instead of exporting
                 # the docker image directly, so squash just slows things down.
                 ("prepublish_plugins", "squash"),
@@ -319,6 +318,19 @@ class PluginsConfigurationBase(object):
 
         if not self.user_params.flatpak.value:
             self.pt.remove_plugin(phase, plugin)
+
+    def render_flatpak_update_dockerfile(self):
+        phase = 'prebuild_plugins'
+        plugin = 'flatpak_update_dockerfile'
+
+        if self.pt.has_plugin_conf(phase, plugin):
+
+            if not self.user_params.flatpak.value:
+                self.pt.remove_plugin(phase, plugin)
+                return
+
+            self.pt.set_plugin_arg_valid(phase, plugin, 'compose_ids',
+                                         self.user_params.compose_ids.value)
 
     def render_koji(self):
         """
@@ -479,21 +491,6 @@ class PluginsConfigurationBase(object):
         self.pt.set_plugin_arg_valid(phase, plugin, 'repourls',
                                      self.user_params.yum_repourls.value)
 
-    def render_resolve_module_compose(self):
-        phase = 'prebuild_plugins'
-        plugin = 'resolve_module_compose'
-
-        if self.pt.has_plugin_conf(phase, plugin):
-            if not self.user_params.flatpak.value:
-                self.pt.remove_plugin(phase, plugin)
-                return
-
-            self.pt.set_plugin_arg_valid(phase, plugin, 'compose_ids',
-                                         self.user_params.compose_ids.value)
-
-            self.pt.set_plugin_arg_valid(phase, plugin, 'signing_intent',
-                                         self.user_params.signing_intent.value)
-
     def render_tag_from_config(self):
         """Configure tag_from_config plugin"""
         phase = 'postbuild_plugins'
@@ -627,6 +624,7 @@ class PluginsConfiguration(PluginsConfigurationBase):
         self.render_check_and_set_platforms()
         self.render_flatpak_create_dockerfile()
         self.render_flatpak_create_oci()
+        self.render_flatpak_update_dockerfile()
         self.render_import_image()
         self.render_inject_parent_image()
         self.render_koji()
@@ -636,7 +634,6 @@ class PluginsConfiguration(PluginsConfigurationBase):
         self.render_orchestrate_build()
         self.render_pull_base_image()
         self.render_resolve_composes()
-        self.render_resolve_module_compose()
         self.render_tag_from_config()
         self.render_koji_delegate()
         self.render_download_remote_source()

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -282,11 +282,11 @@ class TestArrangementV6(ArrangementBase):
                 PLUGIN_ADD_FILESYSTEM_KEY,
                 'inject_parent_image',
                 'pull_base_image',
+                PLUGIN_KOJI_PARENT_KEY,
+                PLUGIN_RESOLVE_COMPOSES_KEY,
                 'bump_release',
                 'add_flatpak_labels',
                 'add_labels_in_dockerfile',
-                PLUGIN_KOJI_PARENT_KEY,
-                PLUGIN_RESOLVE_COMPOSES_KEY,
                 'resolve_remote_source',
             ],
 

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -266,14 +266,13 @@ class TestPluginsConfiguration(object):
         assert get_plugins_from_build_json(build_json)
 
     flatpak_plugins = [
-        ("ow", "prebuild_plugins", "resolve_module_compose"),
         ("ow", "prebuild_plugins", "flatpak_create_dockerfile"),
+        ("ow", "prebuild_plugins", "flatpak_update_dockerfile"),
         ("ow", "prebuild_plugins", "add_flatpak_labels"),
         ("w", "prepublish_plugins", "flatpak_create_oci"),
     ]
 
     not_flatpak_plugins = [
-        ("o", "prebuild_plugins", "resolve_composes"),
         ("w", "prepublish_plugins", "squash"),
         ("o", "exit_plugins", "import_image"),
     ]
@@ -318,7 +317,14 @@ class TestPluginsConfiguration(object):
         self.check_plugin_presence(build_type, plugins,
                                    self.flatpak_plugins, self.not_flatpak_plugins)
 
-        plugin = get_plugin(plugins, "prebuild_plugins", "resolve_module_compose")
+        if build_type == BUILD_TYPE_ORCHESTRATOR:
+            plugin = get_plugin(plugins, "prebuild_plugins", "resolve_composes")
+            assert plugin
+
+        plugin = get_plugin(plugins, "prebuild_plugins", "flatpak_create_dockerfile")
+        assert plugin
+
+        plugin = get_plugin(plugins, "prebuild_plugins", "flatpak_update_dockerfile")
         assert plugin
 
         args = plugin['args']
@@ -328,13 +334,6 @@ class TestPluginsConfiguration(object):
         else:
             assert args['compose_ids'] == compose_ids
 
-        if signing_intent is None:
-            assert 'signing_intent' not in args
-        else:
-            assert args['signing_intent'] == signing_intent
-
-        plugin = get_plugin(plugins, "prebuild_plugins", "flatpak_create_dockerfile")
-        assert plugin
         plugin = get_plugin(plugins, "prebuild_plugins", "add_flatpak_labels")
         assert plugin
 


### PR DESCRIPTION
atomic-reactor is being changed to use the 'resolve_composes' plugin
for Flatpaks, instead of having a separate 'resolve_module_compose',
and to add a new 'flatpak_update_dockerfile' plugin that runs after
'resolve_composes'.
    
The 'resolve_composes' plugin is moved up a bit in the sequence of
orchestrator plugins so that 'flatpak_update_dockerfile' can set the
release label before bump_release runs. As far as I can tell, it should
work as well in the new location as the old location.

See https://github.com/containerbuildsystem/atomic-reactor/pull/1373

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
