### PR TITLE
cleanup: remove references to koji_promote

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -197,7 +197,6 @@ class PluginsConfigurationBase(object):
                 ("postbuild_plugins", "compress"),  # required only to make an archive for Koji
                 ("postbuild_plugins", "compare_components"),
                 ("postbuild_plugins", "import_image"),
-                ("exit_plugins", "koji_promote"),
                 ("exit_plugins", "koji_tag_build"),
                 ("exit_plugins", "import_image"),
                 ("prebuild_plugins", "check_and_set_rebuild"),

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -39,7 +39,6 @@ import pytest
 # of osbs-client
 # But we need to verify the input json against the actual keys, so keeping this list
 # up to date is the best solution.
-PLUGIN_KOJI_PROMOTE_PLUGIN_KEY = 'koji_promote'
 PLUGIN_KOJI_IMPORT_PLUGIN_KEY = 'koji_import'
 PLUGIN_KOJI_UPLOAD_PLUGIN_KEY = 'koji_upload'
 PLUGIN_KOJI_TAG_BUILD_KEY = 'koji_tag_build'

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -856,7 +856,6 @@ class TestPluginsConfiguration(object):
             ("postbuild_plugins", "compress"),
             ("postbuild_plugins", "compare_components"),
             ("postbuild_plugins", "import_image"),
-            ("exit_plugins", "koji_promote"),
             ("exit_plugins", "koji_tag_build"),
             ("exit_plugins", "import_image"),
             ("prebuild_plugins", "check_and_set_rebuild"),


### PR DESCRIPTION
Fixes OSBS-3863

koji_promote is being removed from atomic_reactor, so remove the
references to it from osbs-client.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
