### PR TITLE
api: report incomplete positional arguments to _do_create_build

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -89,6 +89,8 @@ def osbsapi(func):
     return catch_exceptions
 
 
+_REQUIRED_PARAM = object()
+
 logger = logging.getLogger(__name__)
 
 LogEntry = namedtuple('LogEntry', ['platform', 'line'])
@@ -678,7 +680,8 @@ class OSBS(object):
         return user_params
 
     def _do_create_prod_build(self,
-                              git_uri, git_ref, git_branch,
+                              git_uri=_REQUIRED_PARAM, git_ref=_REQUIRED_PARAM,
+                              git_branch=_REQUIRED_PARAM,
                               inner_template=None,
                               outer_template=None,
                               customize_conf=None,
@@ -690,6 +693,14 @@ class OSBS(object):
                               koji_task_id=None,
                               target=None,
                               **kwargs):
+
+        required_params = {"git_uri": git_uri, "git_ref": git_ref, "git_branch": git_branch}
+        missing_params = []
+        for param_name, param_arg in required_params.items():
+            if param_arg is _REQUIRED_PARAM:
+                missing_params.append(param_name)
+        if missing_params:
+            raise OsbsException('required parameter {} missing'.format(", ".join(missing_params)))
 
         if flatpak:
             if isolated:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2688,6 +2688,44 @@ class TestOSBS(object):
                                            build_type=BUILD_TYPE_ORCHESTRATOR,
                                            skip_build=skip_build)
 
+    def test_do_create_prod_build_missing_params(self, osbs, caplog):  # noqa
+        with pytest.raises(OsbsException):
+            osbs._do_create_prod_build(user=TEST_USER,
+                                       inner_template=DEFAULT_INNER_TEMPLATE,
+                                       outer_template=DEFAULT_OUTER_TEMPLATE,
+                                       customize_conf=DEFAULT_CUSTOMIZE_CONF,
+                                       build_type=BUILD_TYPE_ORCHESTRATOR)
+            assert 'git_uri' in caplog.text
+
+        with pytest.raises(OsbsException):
+            osbs._do_create_prod_build(TEST_GIT_URI, user=TEST_USER,
+                                       inner_template=DEFAULT_INNER_TEMPLATE,
+                                       outer_template=DEFAULT_OUTER_TEMPLATE,
+                                       customize_conf=DEFAULT_CUSTOMIZE_CONF,
+                                       build_type=BUILD_TYPE_ORCHESTRATOR)
+            assert 'git_uri' not in caplog.text
+            assert 'git_ref' in caplog.text
+
+        with pytest.raises(OsbsException):
+            osbs._do_create_prod_build(TEST_GIT_URI, TEST_GIT_REF, user=TEST_USER,
+                                       inner_template=DEFAULT_INNER_TEMPLATE,
+                                       outer_template=DEFAULT_OUTER_TEMPLATE,
+                                       customize_conf=DEFAULT_CUSTOMIZE_CONF,
+                                       build_type=BUILD_TYPE_ORCHESTRATOR)
+            assert 'git_uri' not in caplog.text
+            assert 'git_ref' not in caplog.text
+            assert 'git_branch' in caplog.text
+
+        with pytest.raises(OsbsException):
+            osbs._do_create_prod_build(user=TEST_USER,
+                                       inner_template=DEFAULT_INNER_TEMPLATE,
+                                       outer_template=DEFAULT_OUTER_TEMPLATE,
+                                       customize_conf=DEFAULT_CUSTOMIZE_CONF,
+                                       build_type=BUILD_TYPE_ORCHESTRATOR)
+            assert 'git_uri' in caplog.text
+            assert 'git_ref' in caplog.text
+            assert 'git_branch' in caplog.text
+
     # osbs is a fixture here
     def test_config_map(self, osbs):  # noqa
         with open(os.path.join(INPUTS_PATH, "config_map.json")) as fp:


### PR DESCRIPTION
Fixes OSBS-8026

Catch when there are an insufficient number of positional arguments to _do_create_prod_build and report which one is missing.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
