### PR TITLE
repo_utils: validate container.yaml against the schema

### DIFF
--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -98,6 +98,7 @@ Summary:        Python 3 module for OpenShift Build Service
 Group:          Development/Tools
 License:        BSD
 Requires:       python3-dockerfile-parse
+Requires:       python3-jsonschema
 Requires:       python3-requests
 Requires:       python3-requests-kerberos
 Requires:       python3-dateutil
@@ -122,6 +123,7 @@ Summary:        Python 2 module for OpenShift Build Service
 Group:          Development/Tools
 License:        BSD
 Requires:       python-dockerfile-parse
+Requires:       python-jsonschema
 Requires:       python-requests
 Requires:       python-requests-kerberos
 Requires:       python-setuptools

--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -132,13 +132,12 @@ class RepoConfiguration(object):
 
         file_path = os.path.join(dir_path, REPO_CONTAINER_CONFIG)
         if os.path.exists(file_path):
-            with open(file_path) as f:
-                try:
-                    self.container = yaml.safe_load(f) or {}
-                except yaml.scanner.ScannerError as e:
-                    msg = ('Failed to parse YAML file "{file}": {reason}'
-                           .format(file=REPO_CONTAINER_CONFIG, reason=e))
-                    raise OsbsException(msg)
+            try:
+                self.container = read_yaml_from_file_path(file_path, 'schemas/container.json') or {}
+            except Exception as e:
+                msg = ('Failed to load or validate container file "{file}": {reason}'
+                       .format(file=file_path, reason=e))
+                raise OsbsException(msg)
 
         # container values may be set to None
         container_compose = self.container.get('compose') or {}

--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -1,0 +1,280 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+
+  "title": "container image build configuration",
+
+  "type": ["object", "null"],
+  "anyOf": [
+      {
+         "properties": {
+            "go": {
+              "type": "object",
+              "properties": {
+                "modules": {
+                  "type": ["array", "null"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "module": {
+                        "type": "string",
+                        "description": "Top-level Go module (package) name which will be built",
+                        "examples": [
+                          "example.com/go/packagename",
+                          "example.com/go/anotherpackage"
+                        ]
+                      },
+                      "archive": {
+                        "type": "string",
+                        "description": "Possibly-compressed archive containing full source code including dependencies",
+                        "examples": [
+                          "anotherpackage.tar.gz"
+                        ]
+                      },
+                      "path": {
+                        "type": "string",
+                        "description": "Path to directory containing source code (or its parent), possibly within archive",
+                        "examples": [
+                          "anotherpackage-v0.54.1"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": ["module"]
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "platforms": {"$ref": "#/definitions/all_platforms"},
+            "autorebuild": {"$ref": "#/definitions/autorebuild"},
+            "compose": {"$ref": "#/definitions/compose"},
+            "flatpak": {"$ref": "#/definitions/flatpak"},
+            "image_build_method": {"$ref": "#/definitions/image_build_method"},
+            "tags": {"$ref": "#/definitions/tags"},
+            "set_release_env": {"$ref": "#/definitions/set_release_env"},
+            "version": {"$ref": "#/definitions/version"}
+         },
+         "additionalProperties": false
+      },
+
+      {
+         "properties": {
+            "platforms": {"$ref": "#/definitions/all_platforms"},
+            "autorebuild": {"$ref": "#/definitions/autorebuild"},
+            "compose": {"$ref": "#/definitions/compose"},
+            "flatpak": {"$ref": "#/definitions/flatpak"},
+            "image_build_method": {"$ref": "#/definitions/image_build_method"},
+            "remote_source": {
+              "type": ["object", "null"],
+              "properties": {
+                "repo": {
+                  "type": "string",
+                  "description": "URL to the SCM repository",
+                  "examples": [
+                    "https://git.example.com/team/repo.git",
+                    "https://git.example.com/another-repo.git"
+                  ]
+                },
+                "ref": {
+                  "type": "string",
+                  "pattern": "^[0-9a-z]{40}$",
+                  "description": "SCM reference to fetch from repository",
+                  "examples": [
+                    "b55c00f45ec3dfee0c766cea3d395d6e21cc2e5a",
+                    "651abc41170e52866148cc0c99c3671a2ace7002"
+                  ]
+                },
+                "pkg_managers": {
+                  "description": "list of package managers to be used for resolving dependencies",
+                  "type": ["array", "null"],
+                  "items": {
+                      "type": "string",
+                      "examples": [
+                        "gomod"
+                      ]
+                  }
+                },
+                "flags": {
+                  "description": "list of flags to pass to the Cachito request",
+                  "type": ["array", "null"],
+                  "items": {
+                      "type": "string",
+                      "examples": [
+                        "enable-confeti",
+                        "enable-party-popper"
+                      ]
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": ["repo", "ref"]
+            },
+            "tags": {"$ref": "#/definitions/tags"},
+            "set_release_env": {"$ref": "#/definitions/set_release_env"},
+            "version": {"$ref": "#/definitions/version"}
+         },
+         "additionalProperties": false
+      }
+  ],
+
+  "definitions": {
+    "platform": {
+      "type": "string",
+      "description": "Platform name",
+      "examples": [
+        "x86_64",
+        "ppc64le",
+        "armhfp"
+      ]
+    },
+    "platforms": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/platform"
+        },
+        { "type": "array",
+          "items": {
+            "$ref": "#/definitions/platform"
+          }
+        }
+      ]
+    },
+    "all_platforms": {
+      "type": ["object", "null"],
+      "properties": {
+        "only": {
+          "$ref": "#/definitions/platforms",
+          "description": "Platform(s) to build image for"
+        },
+        "not": {
+          "$ref": "#/definitions/platforms",
+          "description": "Platform(s) not to build image for"
+        }
+      },
+      "additionalProperties": false
+    },
+    "autorebuild": {
+      "type": ["object", "null"],
+      "properties": {
+        "from_latest": {
+          "description": "Whether to rebuild from the latest commit",
+          "type": "boolean"
+        },
+        "add_timestamp_to_release": {
+          "description": "Whether to append timestamp to explicitly specified release for autorebuilds",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "compose": {
+      "type": ["object", "null"],
+      "properties": {
+        "packages": {
+          "description": "names of RPMs to include",
+          "type": ["array", "null"],
+          "items": {
+              "type": "string",
+              "examples": [
+                "httpd",
+                "httpd-devel"
+              ]
+          }
+        },
+        "pulp_repos": {
+          "description": "whether to build pulp composes",
+          "type": "boolean"
+        },
+        "modules": {
+          "description": "names of modules to include",
+          "type": ["array", "null"],
+          "items": {
+              "type": "string",
+              "examples": [
+                "module_name1:stream1",
+                "module_name2:stream1"
+              ]
+          }
+        },
+        "signing_intent": {
+          "type": "string",
+          "description": "Name of ODCS signing intent used to verify package signatures",
+          "examples": [
+            "release",
+            "unsigned"
+          ]
+        },
+        "inherit": {
+          "description": "enable inheritance of yum repourls and composes from baseimage build (disabled by default)",
+          "type": "boolean"
+        },
+        "include_unpublished_pulp_repos": {
+          "description": "include unpublished repos in pulp input content-sets",
+          "type": "boolean"
+        },
+        "multilib_method": {
+          "description": "list of options to decide if a package is multilib",
+          "type": ["array", "null"],
+          "items": {
+              "enum": ["none", "iso", "runtime", "devel", "all"]
+          }
+        },
+        "multilib_arches": {
+          "description": "list of arches which will get multilib composes",
+          "type": ["array", "null"],
+          "items": {
+              "type": "string",
+              "examples": [
+                "x86_64",
+                "ppc64le"
+              ]
+          }
+        },
+        "modular_koji_tags": {
+          "description": "tags of modular Koji content to include in the build",
+          "type": ["array", "null"],
+          "items": {
+              "type": "string",
+              "examples": [
+                "f30-modules",
+                "rhel-8.2.1-modules"
+              ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "flatpak": {
+      "type": ["object", "null"],
+      "description": "Information used to build a Flatpak"
+    },
+    "image_build_method": {
+      "description": "build-step plugin to be used",
+      "enum": ["docker_api", "imagebuilder", "buildah_bud"]
+    },
+    "tags": {
+      "type": "array",
+      "description": "Tags to apply to the built image",
+      "examples": [
+        "latest",
+        "1.0",
+        "demo"
+      ]
+    },
+    "set_release_env": {
+      "type": "string",
+      "description": "Name of an environment variable to set in the Dockerfile file with the release number",
+      "examples": [
+        "CONTAINER_RELEASE_NVR",
+        "IMAGE_RELEASE",
+        "OS_BUILD"
+      ]
+    },
+    "version": {
+      "type": "integer",
+      "description": "Deprecated option kept for backwards compatibility. Should not be used",
+      "minimum": 1,
+      "default": 1
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dockerfile-parse
+jsonschema==2.3.0  # to match available in RHEL/CentOS 7
 requests
 requests-kerberos
 six

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -264,7 +264,7 @@ class TestOSBS(object):
         with pytest.raises(OsbsException) as exc_info:
             osbs.create_build(**kwargs)
 
-        err_msg = 'Failed to parse YAML file "{file}"'.format(file=REPO_CONTAINER_CONFIG)
+        err_msg = 'Failed to load or validate container file "{}"'.format(repo_config)
         assert err_msg in str(exc_info.value)
 
     # osbs is a fixture here

--- a/tests/test_repo_utils.py
+++ b/tests/test_repo_utils.py
@@ -11,11 +11,77 @@ from __future__ import absolute_import
 from flexmock import flexmock
 from osbs.exceptions import OsbsException
 from osbs.constants import REPO_CONFIG_FILE, ADDITIONAL_TAGS_FILE, REPO_CONTAINER_CONFIG
-from osbs.repo_utils import RepoInfo, RepoConfiguration, AdditionalTagsConfig, ModuleSpec
+from osbs.repo_utils import (RepoInfo, RepoConfiguration, AdditionalTagsConfig, ModuleSpec,
+                             read_yaml, read_yaml_from_file_path)
 from textwrap import dedent
 
+import json
 import os
+import pkg_resources
 import pytest
+import yaml
+
+
+def test_read_yaml_file_ioerrors(tmpdir):
+    config_path = os.path.join(str(tmpdir), 'nosuchfile.yaml')
+    with pytest.raises(IOError):
+        read_yaml_from_file_path(config_path, 'schemas/nosuchfile.json')
+
+
+@pytest.mark.parametrize('from_file', [True, False])
+@pytest.mark.parametrize('config', [
+    ("""\
+      compose:
+          modules:
+          - mod_name:mod_stream:mod_version
+    """),
+])
+def test_read_yaml_file_or_yaml(tmpdir, from_file, config):
+    expected = yaml.safe_load(config)
+
+    if from_file:
+        config_path = os.path.join(str(tmpdir), 'config.yaml')
+        with open(config_path, 'w') as fp:
+            fp.write(config)
+        output = read_yaml_from_file_path(config_path, 'schemas/container.json')
+    else:
+        output = read_yaml(config, 'schemas/container.json')
+
+    assert output == expected
+
+
+def test_read_yaml_file_bad_extract(tmpdir, caplog):
+    class FakeProvider(object):
+        def get_resource_stream(self, pkg, rsc):
+            raise IOError
+
+    # pkg_resources.resource_stream() cannot be mocked directly
+    # Instead mock the module-level function it calls.
+    (flexmock(pkg_resources)
+        .should_receive('get_provider')
+        .and_return(FakeProvider()))
+
+    config_path = os.path.join(str(tmpdir), 'config.yaml')
+    with open(config_path, 'w'):
+        pass
+
+    with pytest.raises(IOError):
+        read_yaml_from_file_path(config_path, 'schemas/container.json')
+    assert "unable to extract JSON schema, cannot validate" in caplog.text
+
+
+def test_read_yaml_file_bad_decode(tmpdir, caplog):
+    (flexmock(json)
+        .should_receive('load')
+        .and_raise(ValueError))
+
+    config_path = os.path.join(str(tmpdir), 'config.yaml')
+    with open(config_path, 'w'):
+        pass
+
+    with pytest.raises(ValueError):
+        read_yaml_from_file_path(config_path, 'schemas/container.json')
+    assert "unable to decode JSON schema, cannot validate" in caplog.text
 
 
 class TestRepoInfo(object):

--- a/tests/test_repo_utils.py
+++ b/tests/test_repo_utils.py
@@ -116,14 +116,10 @@ class TestRepoConfiguration(object):
         with pytest.raises(OsbsException) as exc_info:
             RepoConfiguration(dir_path=str(tmpdir))
 
-        err_msg = (
-            'Failed to parse YAML file "{file_basename}": while scanning a simple key\n'
-            '  in "{file}", line 2, column 1\n'
-            "could not find expected ':'\n"
-            '  in "{file}", line 2, column 4'
-        ).format(file=yaml_file, file_basename=REPO_CONTAINER_CONFIG)
-
-        assert str(exc_info.value) == err_msg
+        err_msg = str(exc_info.value)
+        assert 'Failed to load or validate container file "{}"'.format(yaml_file) in err_msg
+        assert "could not find expected ':'" in err_msg
+        assert 'line 2, column 4:' in err_msg
 
     @pytest.mark.parametrize(('config_value', 'expected_value'), (
         (None, False),


### PR DESCRIPTION
Fixes OSBS-5734

Move the validation of the container.yaml out of atomic-reactor and into osbs-client.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
