### PR TITLE
Define label com.redhat.delivery.operator.bundle

### DIFF
--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -587,7 +587,8 @@ class Labels(object):
     - LABEL_TYPE_RUN: command to run the image
     - LABEL_TYPE_INSTALL: command to install the image
     - LABEL_TYPE_UNINSTALL: command to uninstall the image
-    - LABEL_TYPE_OPERATOR_MANIFESTS: flags the presence of operators metadata
+    - LABEL_TYPE_OPERATOR_MANIFESTS: flags the presence of appregistry operators metadata
+    - LABEL_TYPE_OPERATOR_BUNDLE_MANIFESTS: flags the presence of operators bundle metadata
     """
     LABEL_TYPE_NAME = object()
     LABEL_TYPE_VERSION = object()
@@ -601,6 +602,7 @@ class Labels(object):
     LABEL_TYPE_INSTALL = object()
     LABEL_TYPE_UNINSTALL = object()
     LABEL_TYPE_OPERATOR_MANIFESTS = object()
+    LABEL_TYPE_OPERATOR_BUNDLE_MANIFESTS = object()
     LABEL_NAMES = {
         LABEL_TYPE_NAME: ('name', 'Name'),
         LABEL_TYPE_VERSION: ('version', 'Version'),
@@ -613,7 +615,8 @@ class Labels(object):
         LABEL_TYPE_RUN: ('run', 'RUN'),
         LABEL_TYPE_INSTALL: ('install', 'INSTALL'),
         LABEL_TYPE_UNINSTALL: ('uninstall', 'UNINSTALL'),
-        LABEL_TYPE_OPERATOR_MANIFESTS: ('com.redhat.delivery.appregistry',)
+        LABEL_TYPE_OPERATOR_MANIFESTS: ('com.redhat.delivery.appregistry',),
+        LABEL_TYPE_OPERATOR_BUNDLE_MANIFESTS: ('com.redhat.delivery.operator.bundle',),
     }
 
     def __init__(self, df_labels):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -474,6 +474,9 @@ def test_get_instance_token_file_name():
     ({"com.redhat.delivery.appregistry": "true"},
      ("get_name_and_value", Labels.LABEL_TYPE_OPERATOR_MANIFESTS),
      ("com.redhat.delivery.appregistry", "true")),
+    ({"com.redhat.delivery.operator.bundle": "true"},
+     ("get_name_and_value", Labels.LABEL_TYPE_OPERATOR_BUNDLE_MANIFESTS),
+     ("com.redhat.delivery.operator.bundle", "true")),
 ])
 def test_labels(labels, fnc, expect):
     label = Labels(labels)


### PR DESCRIPTION
New label for new type of operators delivery.

* OSBS-8634

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
