### PR TITLE
Run pre_check_user_settings plugin on orchestrator

### DIFF
--- a/inputs/orchestrator_inner:6.json
+++ b/inputs/orchestrator_inner:6.json
@@ -4,6 +4,9 @@
       "name": "reactor_config"
     },
     {
+      "name": "check_user_settings"
+    },
+    {
       "name": "check_and_set_rebuild",
       "args": {
         "label_key": "is_autorebuild",

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -273,6 +273,7 @@ class TestArrangementV6(ArrangementBase):
         ORCHESTRATOR_INNER_TEMPLATE: {
             'prebuild_plugins': [
                 'reactor_config',
+                'check_user_settings',
                 'check_and_set_rebuild',
                 'koji_delegate',
                 PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,


### PR DESCRIPTION
Plugin will check if user settings are correct.

Nothing prevent this plugin from running on workers but currently
having only orchestrator is fine.

* OSBS-8634

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
