### PR TITLE
check_user_settings: pass arg if build is flatpak

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -301,6 +301,13 @@ class PluginsConfigurationBase(object):
                     # Malformed config
                     logger.info('Invalid custom configuration found for enable_plugins')
 
+    def render_check_user_settings(self):
+        phase = 'prebuild_plugins'
+        plugin = 'check_user_settings'
+        if self.pt.has_plugin_conf(phase, plugin):
+            self.pt.set_plugin_arg_valid(phase, plugin, 'flatpak',
+                                         self.user_params.flatpak.value)
+
     def render_flatpak_create_dockerfile(self):
         phase = 'prebuild_plugins'
         plugin = 'flatpak_create_dockerfile'
@@ -621,6 +628,7 @@ class PluginsConfiguration(PluginsConfigurationBase):
         self.render_add_yum_repo_by_url()
         self.render_bump_release()
         self.render_check_and_set_platforms()
+        self.render_check_user_settings()
         self.render_flatpak_create_dockerfile()
         self.render_flatpak_create_oci()
         self.render_flatpak_update_dockerfile()

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -321,6 +321,10 @@ class TestPluginsConfiguration(object):
             plugin = get_plugin(plugins, "prebuild_plugins", "resolve_composes")
             assert plugin
 
+            plugin = get_plugin(plugins, "prebuild_plugins", "check_user_settings")
+            assert plugin
+            assert plugin['args']['flatpak'], "Plugin has not set flatpak arg to True"
+
         plugin = get_plugin(plugins, "prebuild_plugins", "flatpak_create_dockerfile")
         assert plugin
 


### PR DESCRIPTION
Plugin has to know if build is flatpak build to skip some checks.

* OSBS-8634

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
