### PR TITLE
operators: Add support for pin_operator_digest

### DIFF
--- a/inputs/orchestrator_inner:6.json
+++ b/inputs/orchestrator_inner:6.json
@@ -56,6 +56,9 @@
     },
     {
       "name": "resolve_remote_source"
+    },
+    {
+      "name": "pin_operator_digest"
     }
   ],
   "buildstep_plugins": [

--- a/inputs/worker_inner:6.json
+++ b/inputs/worker_inner:6.json
@@ -62,6 +62,9 @@
     },
     {
       "name": "add_buildargs_in_dockerfile"
+    },
+    {
+      "name": "pin_operator_digest"
     }
   ],
   "prepublish_plugins": [

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -424,6 +424,15 @@ class PluginsConfigurationBase(object):
         set_arg('platform', self.user_params.platform.value)
         set_arg('report_multiple_digests', True)
 
+    def render_pin_operator_digest(self):
+        phase = 'prebuild_plugins'
+        name = 'pin_operator_digest'
+
+        replacement_pullspecs = self.user_params.operator_bundle_replacement_pullspecs.value
+
+        if replacement_pullspecs and self.pt.has_plugin_conf(phase, name):
+            self.pt.set_plugin_arg(phase, name, 'replacement_pullspecs', replacement_pullspecs)
+
     def render_export_operator_manifests(self):
         phase = 'postbuild_plugins'
         name = 'export_operator_manifests'
@@ -637,6 +646,7 @@ class PluginsConfiguration(PluginsConfigurationBase):
         self.render_koji()
         self.render_koji_tag_build()
         self.render_koji_upload()
+        self.render_pin_operator_digest()
         self.render_export_operator_manifests()
         self.render_orchestrate_build()
         self.render_pull_base_image()

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -357,6 +357,9 @@ class BuildUserParams(BuildCommon):
         self.koji_parent_build = BuildParam('koji_parent_build', allow_none=True)
         self.koji_upload_dir = BuildParam('koji_upload_dir', allow_none=True)
         self.name = BuildIDParam()
+        self.operator_bundle_replacement_pullspecs = BuildParam(
+            'operator_bundle_replacement_pullspecs', allow_none=True
+        )
         self.operator_manifests_extract_platform = BuildParam('operator_manifests_extract_platform',
                                                               allow_none=True)
         self.parent_images_digests = BuildParam('parent_images_digests', allow_none=True)
@@ -403,6 +406,7 @@ class BuildUserParams(BuildCommon):
                    koji_parent_build=None,
                    koji_upload_dir=None,
                    name_label=None,
+                   operator_bundle_replacement_pullspecs=None,
                    operator_manifests_extract_platform=None,
                    auto_build_node_selector=None,
                    explicit_build_node_selector=None,
@@ -441,6 +445,9 @@ class BuildUserParams(BuildCommon):
         :param koji_upload_dir: str, koji directory where the completed image will be uploaded
         :param name_label: str, label of the parent image
         :param user: str, name of the user requesting the build
+        :param operator_bundle_replacement_pullspecs: dict, mapping of original pullspecs to
+                                                      replacement pullspecs for operator manifest
+                                                      bundle builds
         :param operator_manifests_extract_platform: str, indicates which platform should upload
                                                     operator manifests to koji
         :param parent_images_digests: dict, mapping image digests to names and platforms
@@ -516,6 +523,7 @@ class BuildUserParams(BuildCommon):
         self.parent_images_digests.value = parent_images_digests
         self.platforms.value = platforms
         self.operator_manifests_extract_platform.value = operator_manifests_extract_platform
+        self.operator_bundle_replacement_pullspecs.value = operator_bundle_replacement_pullspecs
         self.skip_build.value = skip_build
         self.tags_from_yaml.value = tags_from_yaml
         self.triggered_after_koji_task.value = triggered_after_koji_task

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -288,6 +288,7 @@ class TestArrangementV6(ArrangementBase):
                 'add_flatpak_labels',
                 'add_labels_in_dockerfile',
                 'resolve_remote_source',
+                'pin_operator_digest',
             ],
 
             'buildstep_plugins': [
@@ -340,7 +341,8 @@ class TestArrangementV6(ArrangementBase):
                 'inject_yum_repo',
                 'distribution_scope',
                 'download_remote_source',
-                'add_buildargs_in_dockerfile'
+                'add_buildargs_in_dockerfile',
+                'pin_operator_digest',
             ],
 
             'buildstep_plugins': [

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -786,6 +786,26 @@ class TestPluginsConfiguration(object):
                 get_plugin(plugins, plugin_type, plugin_name)
             assert 'no koji parent build in user parameters' in caplog.text
 
+    def test_render_pin_operator_digest(self):
+        plugin_type = "prebuild_plugins"
+        plugin_name = "pin_operator_digest"
+
+        replacement_pullspecs = {
+            'foo/fedora:30': 'bar/fedora@sha256:deadbeef'
+        }
+        extra_args = {
+            'operator_bundle_replacement_pullspecs': replacement_pullspecs
+        }
+
+        self.mock_repo_info()
+        user_params = get_sample_user_params(extra_args)
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        plugin_value = plugin_value_get(plugins, plugin_type, plugin_name,
+                                        'args', 'replacement_pullspecs')
+        assert plugin_value == replacement_pullspecs
+
     @pytest.mark.parametrize('extract_platform', ('x86_64', 'aarch64'))
     @pytest.mark.parametrize('build_type', (BUILD_TYPE_WORKER, BUILD_TYPE_ORCHESTRATOR))
     def test_render_export_operator_manifests(self, extract_platform, build_type):

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -256,6 +256,9 @@ class TestBuildUserParams(object):
             'isolated': False,
             'koji_parent_build': 'fedora-26-9',
             'koji_target': 'tothepoint',
+            'operator_bundle_replacement_pullspecs': {
+                'foo/fedora:30': 'bar/fedora@sha256:deadbeef'
+            },
             # "orchestrator_deadline": 4,
             'parent_images_digests': {
                 'registry.fedorahosted.org/fedora:29': {
@@ -317,6 +320,9 @@ class TestBuildUserParams(object):
             "koji_parent_build": "fedora-26-9",
             "koji_target": "tothepoint",
             "name": "path-master-cd1e4",
+            'operator_bundle_replacement_pullspecs': {
+                'foo/fedora:30': 'bar/fedora@sha256:deadbeef'
+            },
             "orchestrator_deadline": 4,
             'parent_images_digests': {
                 'registry.fedorahosted.org/fedora:29': {


### PR DESCRIPTION
* OSBS-8637

Add BuildUserParams property and PluginsConfiguration render method to
allow orchestrator to pass the 'replacement_pullspecs' param to worker
instances of 'pin_operator_digest'

Add 'pin_operator_digest' to orchestrator and worker inner
configurations

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
