### PR TITLE
spec: add builddep python3-jsonschema

### DIFF
--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -72,6 +72,7 @@ BuildRequires:  python3-dockerfile-parse
 BuildRequires:  python3-requests
 BuildRequires:  python3-requests-kerberos
 BuildRequires:  python3-PyYAML
+BuildRequires:  python3-jsonschema
 %else
 BuildRequires:  pytest
 BuildRequires:  python-flexmock


### PR DESCRIPTION
Fixes: #948 
Read the issue. Thanks
https://copr.fedorainfracloud.org/coprs/martstyk/osbs-client/build/1299777/

It is not necessary to add it under EL7 as with_check is set to 1 only for Fedora  

Signed-off-by: Martin Styk <mastyk@redhat.com>

Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
