### PR TITLE
Add support for Packit as a Service

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,11 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    - epel-7-x86_64
+    - epel-8-x86_64
+    - fedora-all


### PR DESCRIPTION
I guess it would be helpful for all contributors to have automated checks for RPM builds. This can mitigate issues like #948 (PR #949).

At the start, I included EL7, EL8, Fedora stable releases + Fedora rawhide. If I'm missing something or something new needs to be added, multiarch for example, just tell me.

You already have approved organization by Packit
Signed-off-by: Martin Styk <mastyk@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
