### PR TITLE
operator manifests: Validate user configuration

### DIFF
--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -49,6 +49,7 @@
             "autorebuild": {"$ref": "#/definitions/autorebuild"},
             "compose": {"$ref": "#/definitions/compose"},
             "flatpak": {"$ref": "#/definitions/flatpak"},
+            "operator_manifest": {"$ref": "#/definitions/operator_manifest"},
             "image_build_method": {"$ref": "#/definitions/image_build_method"},
             "tags": {"$ref": "#/definitions/tags"},
             "set_release_env": {"$ref": "#/definitions/set_release_env"},
@@ -63,6 +64,7 @@
             "autorebuild": {"$ref": "#/definitions/autorebuild"},
             "compose": {"$ref": "#/definitions/compose"},
             "flatpak": {"$ref": "#/definitions/flatpak"},
+            "operator_manifest": {"$ref": "#/definitions/operator_manifest"},
             "image_build_method": {"$ref": "#/definitions/image_build_method"},
             "remote_source": {
               "type": ["object", "null"],
@@ -242,6 +244,19 @@
           }
         }
       },
+      "additionalProperties": false
+    },
+    "operator_manifest": {
+      "description": "Configuration for operator manifest bundle builds",
+      "type": "object",
+      "properties": {
+        "manifests_dir": {
+          "description": "Relative path to directory containing operator manifests",
+          "type": "string",
+          "pattern": "^[^/].*$"
+        }
+      },
+      "required": ["manifests_dir"],
       "additionalProperties": false
     },
     "flatpak": {


### PR DESCRIPTION
* OSBS-8637

Add operator_manifest validation to container.yaml

This was already added to atomic-reactor, but container.yaml validation
has since been moved to osbs-client

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
