### PR TITLE
operator manifests: Unify configuration naming

### DIFF
--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -49,7 +49,7 @@
             "autorebuild": {"$ref": "#/definitions/autorebuild"},
             "compose": {"$ref": "#/definitions/compose"},
             "flatpak": {"$ref": "#/definitions/flatpak"},
-            "operator_manifest": {"$ref": "#/definitions/operator_manifest"},
+            "operator_manifests": {"$ref": "#/definitions/operator_manifests"},
             "image_build_method": {"$ref": "#/definitions/image_build_method"},
             "tags": {"$ref": "#/definitions/tags"},
             "set_release_env": {"$ref": "#/definitions/set_release_env"},
@@ -64,7 +64,7 @@
             "autorebuild": {"$ref": "#/definitions/autorebuild"},
             "compose": {"$ref": "#/definitions/compose"},
             "flatpak": {"$ref": "#/definitions/flatpak"},
-            "operator_manifest": {"$ref": "#/definitions/operator_manifest"},
+            "operator_manifests": {"$ref": "#/definitions/operator_manifests"},
             "image_build_method": {"$ref": "#/definitions/image_build_method"},
             "remote_source": {
               "type": ["object", "null"],
@@ -246,7 +246,7 @@
       },
       "additionalProperties": false
     },
-    "operator_manifest": {
+    "operator_manifests": {
       "description": "Configuration for operator manifest bundle builds",
       "type": "object",
       "properties": {


### PR DESCRIPTION
Change operator_manifest in container.yaml to operator_manifestS to
unify it with the reactor-config-map option.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
