### PR TITLE
Import unicode_literals in labels module

### DIFF
--- a/osbs/utils/labels.py
+++ b/osbs/utils/labels.py
@@ -7,7 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 
 class Labels(object):


### PR DESCRIPTION
In cea3df7, we moved the Labels class into its own module. When doing
so, we did not import unicode_literals to the new module. As a
consequence, the keys in the labels dicts became 'str's in python 2.
This patch sets osbs-client back to the former behavior, which is py2/3
consistent.

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
