### PR TITLE
operator manifests: Validate repo_replacements

### DIFF
--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -254,6 +254,31 @@
           "description": "Relative path to directory containing operator manifests",
           "type": "string",
           "pattern": "^[^/].*$"
+        },
+        "repo_replacements": {
+          "description": "Additional replacements for repos not available in OSBS site config",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "registry": {
+                "description": "Configure replacements for this registry",
+                "type": "string"
+              },
+              "package_mappings": {
+                "description": "Repo replacement mappings",
+                "type": "object",
+                "patternProperties": {
+                  ".*": {"type": "string"}
+                },
+                "examples": [
+                  {"foo-bar": "foo/bar", "spam-eggs": "spam/eggs"}
+                ]
+              }
+            },
+            "required": ["registry", "package_mappings"],
+            "additionalProperties": false
+          }
         }
       },
       "required": ["manifests_dir"],


### PR DESCRIPTION
* OSBS-8639

Add validation for operator_manifest.repo_replacements, where the user
can configure container image repo replacements that are not available
in OSBS site-configuration.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
