### PR TITLE
improve read_yaml between osbs-client and atomic-reactor

### DIFF
--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -12,67 +12,17 @@ from __future__ import print_function, absolute_import, unicode_literals
 from osbs.exceptions import OsbsException, OsbsValidationException
 from osbs.constants import REPO_CONFIG_FILE, ADDITIONAL_TAGS_FILE, REPO_CONTAINER_CONFIG
 from osbs.utils.labels import Labels
+from osbs.utils.yaml import read_yaml_from_file_path
 from six import StringIO
 from six.moves.configparser import ConfigParser
-from pkg_resources import resource_stream
 from textwrap import dedent
 
-import codecs
-import json
-import jsonschema
 import logging
 import os
 import re
-import yaml
 
 
 logger = logging.getLogger(__name__)
-
-
-def read_yaml_from_file_path(file_path, schema):
-    with open(file_path) as f:
-        yaml_data = f.read()
-    return read_yaml(yaml_data, schema)
-
-
-def read_yaml(yaml_data, schema):
-    """
-    :param yaml_data: string, yaml content
-    """
-    try:
-        resource = resource_stream('osbs', schema)
-        schema = codecs.getreader('utf-8')(resource)
-    except (IOError, TypeError):
-        logger.error('unable to extract JSON schema, cannot validate')
-        raise
-
-    try:
-        schema = json.load(schema)
-    except ValueError:
-        logger.error('unable to decode JSON schema, cannot validate')
-        raise
-    data = yaml.safe_load(yaml_data)
-    validator = jsonschema.Draft4Validator(schema=schema)
-    try:
-        jsonschema.Draft4Validator.check_schema(schema)
-        validator.validate(data)
-    except jsonschema.SchemaError:
-        logger.error('invalid schema, cannot validate')
-        raise
-    except jsonschema.ValidationError:
-        for error in validator.iter_errors(data):
-            path = "".join(
-                ('[{}]' if isinstance(element, int) else '.{}').format(element)
-                for element in error.path
-            )
-
-            if path.startswith('.'):
-                path = path[1:]
-
-            logger.error('validation error (%s): %s', path or 'at top level', error.message)
-        raise
-
-    return data
 
 
 class RepoInfo(object):

--- a/osbs/utils/yaml.py
+++ b/osbs/utils/yaml.py
@@ -1,0 +1,72 @@
+"""
+Copyright (c) 2020 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+
+from __future__ import absolute_import, unicode_literals
+
+from pkg_resources import resource_stream
+
+import codecs
+import json
+import jsonschema
+import logging
+import yaml
+
+
+logger = logging.getLogger(__name__)
+
+
+def read_yaml_from_file_path(file_path, schema):
+    """
+    :param yaml_data: string, yaml content
+    :param schema: string, file path to the JSON schema
+    """
+    with open(file_path) as f:
+        yaml_data = f.read()
+    return read_yaml(yaml_data, schema)
+
+
+def read_yaml(yaml_data, schema):
+    """
+    :param yaml_data: string, yaml content
+    :param schema: string, file path to the JSON schema
+    """
+    try:
+        resource = resource_stream('osbs', schema)
+        schema = codecs.getreader('utf-8')(resource)
+    except (IOError, TypeError):
+        logger.error('unable to extract JSON schema, cannot validate')
+        raise
+
+    try:
+        schema = json.load(schema)
+    except ValueError:
+        logger.error('unable to decode JSON schema, cannot validate')
+        raise
+    data = yaml.safe_load(yaml_data)
+    validator = jsonschema.Draft4Validator(schema=schema)
+    try:
+        jsonschema.Draft4Validator.check_schema(schema)
+        validator.validate(data)
+    except jsonschema.SchemaError:
+        logger.error('invalid schema, cannot validate')
+        raise
+    except jsonschema.ValidationError:
+        for error in validator.iter_errors(data):
+            path = "".join(
+                ('[{}]' if isinstance(element, int) else '.{}').format(element)
+                for element in error.path
+            )
+
+            if path.startswith('.'):
+                path = path[1:]
+
+            logger.error('validation error (%s): %s', path or 'at top level', error.message)
+        raise
+
+    return data

--- a/osbs/utils/yaml.py
+++ b/osbs/utils/yaml.py
@@ -21,24 +21,30 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
-def read_yaml_from_file_path(file_path, schema):
+def read_yaml_from_file_path(file_path, schema, package=None):
     """
     :param yaml_data: string, yaml content
     :param schema: string, file path to the JSON schema
+    :package: string, package name containing the schema
     """
     with open(file_path) as f:
         yaml_data = f.read()
-    return read_yaml(yaml_data, schema)
+    return read_yaml(yaml_data, schema, package)
 
 
-def read_yaml(yaml_data, schema):
+def read_yaml(yaml_data, schema, package=None):
     """
     :param yaml_data: string, yaml content
     :param schema: string, file path to the JSON schema
+    :package: string, package name containing the schema
     """
+    package = package or 'osbs'
     try:
-        resource = resource_stream('osbs', schema)
+        resource = resource_stream(package, schema)
         schema = codecs.getreader('utf-8')(resource)
+    except (ImportError):
+        logger.error('Unable to find package %s', package)
+        raise
     except (IOError, TypeError):
         logger.error('unable to extract JSON schema, cannot validate')
         raise

--- a/tests/test_repo_utils.py
+++ b/tests/test_repo_utils.py
@@ -12,77 +12,12 @@ from flexmock import flexmock
 from osbs.exceptions import OsbsException, OsbsValidationException
 from osbs.constants import REPO_CONFIG_FILE, ADDITIONAL_TAGS_FILE, REPO_CONTAINER_CONFIG
 from osbs.utils.labels import Labels
-from osbs.repo_utils import (RepoInfo, RepoConfiguration, AdditionalTagsConfig, ModuleSpec,
-                             read_yaml, read_yaml_from_file_path)
+from osbs.repo_utils import RepoInfo, RepoConfiguration, AdditionalTagsConfig, ModuleSpec
 from textwrap import dedent
 
-import json
 import os
-import pkg_resources
 import pytest
 import yaml
-
-
-def test_read_yaml_file_ioerrors(tmpdir):
-    config_path = os.path.join(str(tmpdir), 'nosuchfile.yaml')
-    with pytest.raises(IOError):
-        read_yaml_from_file_path(config_path, 'schemas/nosuchfile.json')
-
-
-@pytest.mark.parametrize('from_file', [True, False])
-@pytest.mark.parametrize('config', [
-    ("""\
-      compose:
-          modules:
-          - mod_name:mod_stream:mod_version
-    """),
-])
-def test_read_yaml_file_or_yaml(tmpdir, from_file, config):
-    expected = yaml.safe_load(config)
-
-    if from_file:
-        config_path = os.path.join(str(tmpdir), 'config.yaml')
-        with open(config_path, 'w') as fp:
-            fp.write(config)
-        output = read_yaml_from_file_path(config_path, 'schemas/container.json')
-    else:
-        output = read_yaml(config, 'schemas/container.json')
-
-    assert output == expected
-
-
-def test_read_yaml_file_bad_extract(tmpdir, caplog):
-    class FakeProvider(object):
-        def get_resource_stream(self, pkg, rsc):
-            raise IOError
-
-    # pkg_resources.resource_stream() cannot be mocked directly
-    # Instead mock the module-level function it calls.
-    (flexmock(pkg_resources)
-        .should_receive('get_provider')
-        .and_return(FakeProvider()))
-
-    config_path = os.path.join(str(tmpdir), 'config.yaml')
-    with open(config_path, 'w'):
-        pass
-
-    with pytest.raises(IOError):
-        read_yaml_from_file_path(config_path, 'schemas/container.json')
-    assert "unable to extract JSON schema, cannot validate" in caplog.text
-
-
-def test_read_yaml_file_bad_decode(tmpdir, caplog):
-    (flexmock(json)
-        .should_receive('load')
-        .and_raise(ValueError))
-
-    config_path = os.path.join(str(tmpdir), 'config.yaml')
-    with open(config_path, 'w'):
-        pass
-
-    with pytest.raises(ValueError):
-        read_yaml_from_file_path(config_path, 'schemas/container.json')
-    assert "unable to decode JSON schema, cannot validate" in caplog.text
 
 
 class TestRepoInfo(object):

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -1,0 +1,80 @@
+"""
+Copyright (c) 2020 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import absolute_import
+
+from flexmock import flexmock
+from osbs.utils.yaml import read_yaml, read_yaml_from_file_path
+
+import json
+import os
+import pkg_resources
+import pytest
+import yaml
+
+
+def test_read_yaml_file_ioerrors(tmpdir):
+    config_path = os.path.join(str(tmpdir), 'nosuchfile.yaml')
+    with pytest.raises(IOError):
+        read_yaml_from_file_path(config_path, 'schemas/nosuchfile.json')
+
+
+@pytest.mark.parametrize('from_file', [True, False])
+@pytest.mark.parametrize('config', [
+    ("""\
+      compose:
+          modules:
+          - mod_name:mod_stream:mod_version
+    """),
+])
+def test_read_yaml_file_or_yaml(tmpdir, from_file, config):
+    expected = yaml.safe_load(config)
+
+    if from_file:
+        config_path = os.path.join(str(tmpdir), 'config.yaml')
+        with open(config_path, 'w') as fp:
+            fp.write(config)
+        output = read_yaml_from_file_path(config_path, 'schemas/container.json')
+    else:
+        output = read_yaml(config, 'schemas/container.json')
+
+    assert output == expected
+
+
+def test_read_yaml_file_bad_extract(tmpdir, caplog):
+    class FakeProvider(object):
+        def get_resource_stream(self, pkg, rsc):
+            raise IOError
+
+    # pkg_resources.resource_stream() cannot be mocked directly
+    # Instead mock the module-level function it calls.
+    (flexmock(pkg_resources)
+        .should_receive('get_provider')
+        .and_return(FakeProvider()))
+
+    config_path = os.path.join(str(tmpdir), 'config.yaml')
+    with open(config_path, 'w'):
+        pass
+
+    with pytest.raises(IOError):
+        read_yaml_from_file_path(config_path, 'schemas/container.json')
+    assert "unable to extract JSON schema, cannot validate" in caplog.text
+
+
+def test_read_yaml_file_bad_decode(tmpdir, caplog):
+    (flexmock(json)
+        .should_receive('load')
+        .and_raise(ValueError))
+
+    config_path = os.path.join(str(tmpdir), 'config.yaml')
+    with open(config_path, 'w'):
+        pass
+
+    with pytest.raises(ValueError):
+        read_yaml_from_file_path(config_path, 'schemas/container.json')
+    assert "unable to decode JSON schema, cannot validate" in caplog.text

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -46,6 +46,12 @@ def test_read_yaml_file_or_yaml(tmpdir, from_file, config):
     assert output == expected
 
 
+def test_read_yaml_bad_package(caplog):
+    with pytest.raises(ImportError):
+        read_yaml("", 'schemas/container.json', package='bad_package')
+    assert 'Unable to find package bad_package' in caplog.text
+
+
 def test_read_yaml_file_bad_extract(tmpdir, caplog):
     class FakeProvider(object):
         def get_resource_stream(self, pkg, rsc):


### PR DESCRIPTION
OSBS-8786

Move read_yaml() and related functions out of repo_utils and into osbs/utils/yaml.py.

Adjust read_yaml() to take a package file which defaults to 'osbs'.

atomic-reactor can now use this version of read_yaml() to read it's own files from its package.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
