### PR TITLE
Fix tito builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ target/
 # RPMs, tars
 *.rpm
 *.tar.gz
+
+# Tito
+!rel-eng/lib/

--- a/rel-eng/lib/builder.py
+++ b/rel-eng/lib/builder.py
@@ -1,0 +1,8 @@
+from tito.builder import Builder
+
+
+class OsbsClientBuilder(Builder):
+
+    def _get_tgz_name_and_ver(self):
+        """ Returns name of tgz created by tito """
+        return "%s" % self.display_version

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,9 +1,10 @@
 [buildconfig]
-builder = tito.builder.Builder
+builder = builder.OsbsClientBuilder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
 tag_format = {version}
+lib_dir = rel-eng/lib
 
 [version_template]
 destination_file = ./osbs/version.py


### PR DESCRIPTION
This should fix the problem when tito is not able to create SRPM, due to missing tarball.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
