### PR TITLE
operator manifests: Validate opt-out options

### DIFF
--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -255,6 +255,21 @@
           "type": "string",
           "pattern": "^[^/].*$"
         },
+        "enable_digest_pinning": {
+          "description": "Replace floating tags with manifest list digests?",
+          "type": "boolean",
+          "default": true
+        },
+        "enable_repo_replacements": {
+          "description": "Replace namespace/repo based on component label in image?",
+          "type": "boolean",
+          "default": true
+        },
+        "enable_registry_replacements": {
+          "description": "Replace registry based on OSBS site configuration?",
+          "type": "boolean",
+          "default": true
+        },
         "repo_replacements": {
           "description": "Additional replacements for repos not available in OSBS site config",
           "type": "array",


### PR DESCRIPTION
* OSBS-8789

Users can configure whether to enable digest pinning, repo replacements
and registry replacements during operator manifest bundle builds in
container.yaml.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
