### PR TITLE
Enable Stickler CI's 'remark-lint' (Markdown linter)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length=100
+max-line-length=72

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,5 +1,19 @@
 {
   "plugins": [
-    "remark-preset-lint-markdown-style-guide"
+    "remark-preset-lint-markdown-style-guide",
+    "remark-lint-no-dead-urls",
+    "remark-lint-match-punctuation",
+    "remark-lint-mdash-style",
+    "remark-lint-no-chinese-punctuation-in-number",
+    "remark-lint-no-dead-urls",
+    "remark-lint-no-repeat-punctuation",
+    "remark-lint-emoji-limit",
+    "remark-lint-no-empty-sections",
+    "remark-lint-heading-length",
+    "remark-lint-heading-whitespace",
+    "remark-lint-are-links-valid",
+    "remark-lint-spaces-around-number",
+    "remark-lint-spaces-around-word",
+    "remark-lint-no-url-trailing-slash"
   ]
 }

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "remark-preset-lint-markdown-style-guide"
+  ]
+}
+

--- a/.remarkrc
+++ b/.remarkrc
@@ -3,4 +3,3 @@
     "remark-preset-lint-markdown-style-guide"
   ]
 }
-

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,19 +1,5 @@
 {
   "plugins": [
-    "remark-preset-lint-markdown-style-guide",
-    "remark-lint-no-dead-urls",
-    "remark-lint-match-punctuation",
-    "remark-lint-mdash-style",
-    "remark-lint-no-chinese-punctuation-in-number",
-    "remark-lint-no-dead-urls",
-    "remark-lint-no-repeat-punctuation",
-    "remark-lint-emoji-limit",
-    "remark-lint-no-empty-sections",
-    "remark-lint-heading-length",
-    "remark-lint-heading-whitespace",
-    "remark-lint-are-links-valid",
-    "remark-lint-spaces-around-number",
-    "remark-lint-spaces-around-word",
-    "remark-lint-no-url-trailing-slash"
+    "remark-preset-lint-recommended"
   ]
 }

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -3,3 +3,6 @@ linters:
     max-line-length: 100
   shellcheck:
     shell: bash
+  remarklint:
+    fixer: true
+

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -4,5 +4,3 @@ linters:
   shellcheck:
     shell: bash
   remarklint:
-    fixer: true
-

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -4,6 +4,3 @@ linters:
   shellcheck:
     shell: bash
   remarklint:
-    fixer: true
-fixers:
-  enable: true

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -4,3 +4,6 @@ linters:
   shellcheck:
     shell: bash
   remarklint:
+    fixer: true
+fixers:
+  enable: true

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,6 @@
 linters:
   flake8:
-    max-line-length: 100
+    max-line-length: 72
   shellcheck:
     shell: bash
   remarklint:


### PR DESCRIPTION

Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
