### PR TITLE
Image owners can make ODCS ignore missing content sets,

### DIFF
--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -210,6 +210,10 @@
           "description": "enable inheritance of yum repourls and composes from baseimage build (disabled by default)",
           "type": "boolean"
         },
+        "ignore_absent_pulp_repos": {
+          "description": "ignore absent content sets",
+          "type": "boolean"
+        },
         "include_unpublished_pulp_repos": {
           "description": "include unpublished repos in pulp input content-sets",
           "type": "boolean"


### PR DESCRIPTION
ignore_absent_pulp_repos option in container.yaml

* CLOUDBLD-125

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
