### PR TITLE
Pass new param to download_remote_source plugin

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -601,6 +601,8 @@ class PluginsConfigurationBase(object):
                                    self.user_params.remote_source_url.value)
             self.pt.set_plugin_arg(phase, plugin, 'remote_source_build_args',
                                    self.user_params.remote_source_build_args.value)
+            self.pt.set_plugin_arg(phase, plugin, 'remote_source_configs',
+                                   self.user_params.remote_source_configs.value)
 
     def render_resolve_remote_source(self):
         phase = 'prebuild_plugins'

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -347,6 +347,7 @@ class BuildUserParams(BuildCommon):
         self.platforms = BuildParam('platforms', allow_none=True)
         self.release = BuildParam('release', allow_none=True)
         self.remote_source_build_args = BuildParam('remote_source_build_args', allow_none=True)
+        self.remote_source_configs = BuildParam('remote_source_configs', allow_none=True)
         self.remote_source_url = BuildParam('remote_source_url', allow_none=True)
         self.skip_build = BuildParam('skip_build', allow_none=True)
         self.tags_from_yaml = BuildParam('tags_from_yaml', allow_none=True)
@@ -399,8 +400,9 @@ class BuildUserParams(BuildCommon):
                    platform=None,
                    platforms=None,
                    release=None,
-                   remote_source_url=None,
                    remote_source_build_args=None,
+                   remote_source_configs=None,
+                   remote_source_url=None,
                    repo_info=None,
                    skip_build=None,
                    tags_from_yaml=None,
@@ -489,8 +491,9 @@ class BuildUserParams(BuildCommon):
         self.git_ref.value = git_ref
         self.git_uri.value = git_uri
 
-        self.remote_source_url.value = remote_source_url
         self.remote_source_build_args.value = remote_source_build_args
+        self.remote_source_configs.value = remote_source_configs
+        self.remote_source_url.value = remote_source_url
         self.release.value = release
         self.build_type.value = build_type
 

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -934,12 +934,15 @@ class TestPluginsConfiguration(object):
                 assert get_plugin(plugins, 'prebuild_plugins', 'koji_delegate')
 
     @pytest.mark.parametrize('build_type', (BUILD_TYPE_ORCHESTRATOR, BUILD_TYPE_WORKER))
-    @pytest.mark.parametrize('remote_source_url', (None, 'some_url'))
     @pytest.mark.parametrize('remote_source_build_args', (None, 'some_args'))
+    @pytest.mark.parametrize('remote_source_configs', (None, ['some configs']))
+    @pytest.mark.parametrize('remote_source_url', (None, 'some_url'))
     def test_render_download_remote_sources(self, build_type, remote_source_url,
-                                            remote_source_build_args):
+                                            remote_source_build_args,
+                                            remote_source_configs):
         extra_args = {
             'remote_source_url': remote_source_url,
+            'remote_source_configs': remote_source_configs,
             'remote_source_build_args': remote_source_build_args
         }
         user_params = get_sample_user_params(extra_args=extra_args, build_type=build_type)
@@ -952,6 +955,7 @@ class TestPluginsConfiguration(object):
                                            'download_remote_source', 'args')
 
             assert plugin_args.get('remote_source_url') == remote_source_url
+            assert plugin_args.get('remote_source_configs') == remote_source_configs
             assert plugin_args.get('remote_source_build_args') == remote_source_build_args
 
         else:


### PR DESCRIPTION
remote_source_configs is a new argument to be passed to the
download_remote_source plugin. It carries information on cachito request
configuration files.

* CLOUDBLD-427

Signed-off-by: Athos Ribeiro <athos@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
