### PR TITLE
 Correctly handle `docker-pullable`-prefixed container_image_ids

### DIFF
--- a/osbs/build/pod_response.py
+++ b/osbs/build/pod_response.py
@@ -41,13 +41,18 @@ class PodResponse(object):
         if statuses is None:
             return {}
 
-        def remove_prefix(image_id, prefix):
-            if image_id.startswith(prefix):
-                return image_id[len(prefix):]
-
+        def remove_prefix(image_id):
+            # Can *currently* be one of None, 'docker://', or
+            #     'docker-pullable://', but is subject to change.
+            try:
+                # Raises 'ValueError' if not found
+                index = image_id.index('://')
+                image_id = image_id[index + 3:]
+            except ValueError:
+                pass
             return image_id
 
-        return {status['image']: remove_prefix(status['imageID'], 'docker://')
+        return {status['image']: remove_prefix(status['imageID'])
                 for status in statuses}
 
     def get_failure_reason(self):

--- a/tests/build_/test_pod_response.py
+++ b/tests/build_/test_pod_response.py
@@ -59,6 +59,19 @@ class TestPodResponse(object):
                  'imageID': 'docker://imageID2',
              },
          ]),
+
+        # New normal case
+        ({'image3': 'imageID3', 'image4': 'imageID4'},
+         [
+             {
+                 'image': 'image3',
+                 'imageID': 'docker-pullable://imageID3',
+             },
+             {
+                 'image': 'image4',
+                 'imageID': 'docker-pullable://imageID4',
+             },
+         ]),
     ])
     def test_container_image_ids(self, expect_image_ids, container_statuses):
         pod_json = deepcopy(self.GENERIC_POD_JSON)


### PR DESCRIPTION
* CLOUDBLD-157

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
