### PR TITLE
Revert jsonschema validation patch

### DIFF
--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -10,8 +10,6 @@ from __future__ import absolute_import
 
 from flexmock import flexmock
 from osbs.utils.yaml import read_yaml, read_yaml_from_file_path
-from osbs.exceptions import OsbsValidationException
-from osbs.constants import PY3
 
 import json
 import os
@@ -86,27 +84,3 @@ def test_read_yaml_file_bad_decode(tmpdir, caplog):
     with pytest.raises(ValueError):
         read_yaml_from_file_path(config_path, 'schemas/container.json')
     assert "unable to decode JSON schema, cannot validate" in caplog.text
-
-
-@pytest.mark.parametrize(('config', 'expected'), [
-    ("""\
-        operator_manifests:
-            enable_digest_pinning: true
-            repo_replacements: [] """,
-     ("at top level: validating 'anyOf' has failed "
-      "({}'manifests_dir' is a required property)"
-      ).format('' if PY3 else 'u')),
-    ("""\
-        compose:
-            packages: []
-            pulp_repos: true
-        mage_build_method: "imagebuilder" """,
-     ("at top level: validating 'anyOf' has failed "
-      "(Additional properties are not allowed ('mage_build_method' was unexpected))")),
-])
-def test_read_yaml_validation_error(config, expected, caplog):
-    with pytest.raises(OsbsValidationException) as exc_info:
-        read_yaml(config, 'schemas/container.json')
-
-    assert "schema validation error" in caplog.text
-    assert expected == str(exc_info.value)


### PR DESCRIPTION
Atomic-reactor unit-tests depend on osbs-client, this was a breaking change.

We will need to re-do these changes but also make sure they do not break atomic-reactor (or update atomic-reactor tests accordingly).

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
