### PR TITLE
Drop ATOMIC_REACTOR_PLUGINS from template

### DIFF
--- a/inputs/orchestrator.json
+++ b/inputs/orchestrator.json
@@ -40,10 +40,7 @@
           "name": "{{BUILD_IMAGE}}"
         },
         "exposeDockerSocket": true,
-        "env": [{
-          "name": "ATOMIC_REACTOR_PLUGINS",
-          "value": "TBD"
-        }],
+        "env": [],
         "secrets": []
       }
     }

--- a/inputs/worker.json
+++ b/inputs/worker.json
@@ -26,10 +26,7 @@
           "name": "{{BUILD_IMAGE}}"
         },
         "exposeDockerSocket": true,
-        "env": [{
-          "name": "ATOMIC_REACTOR_PLUGINS",
-          "value": "TBD"
-        }],
+        "env": [],
         "secrets": []
       }
     }

--- a/osbs/build/build_requestv2.py
+++ b/osbs/build/build_requestv2.py
@@ -60,14 +60,6 @@ class BaseBuildRequest(object):
         if self._build_json_store and not user_params.build_json_dir.value:
             self.user_params.build_json_dir.value = self._build_json_store
 
-    def delete_atomic_reactor_placeholder(self):
-        """Delete the ATOMIC_REACTOR_PLUGINS placeholder"""
-        custom_strategy = self.template['spec']['strategy']['customStrategy']
-        for (index, env) in enumerate(custom_strategy['env']):
-            if env['name'] == 'ATOMIC_REACTOR_PLUGINS':
-                del custom_strategy['env'][index]
-                break
-
     @abc.abstractmethod
     def render(self, validate=True):
         # the api is required for build requests
@@ -86,7 +78,6 @@ class BaseBuildRequest(object):
         self.adjust_for_scratch()
         self.set_reactor_config()
         self.render_user_params()
-        self.delete_atomic_reactor_placeholder()
 
         # Set required_secrets based on reactor_config
         # Set worker_token_secrets based on reactor_config, if any

--- a/tests/build_/test_build_requestv2.py
+++ b/tests/build_/test_build_requestv2.py
@@ -227,7 +227,6 @@ class TestBuildRequestV2(object):
         assert envs['REACTOR_CONFIG'][0]['configMapKeyRef'] == configmapkeyref
 
         assert 'USER_PARAMS' in envs
-        assert 'ATOMIC_REACTOR_PLUGINS' not in envs
 
     @pytest.mark.parametrize(('build_from', 'is_image', 'valid'), (
         (None, False, False),

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -80,10 +80,7 @@ TEST_BUILD_JSON = {
                     "name": "buildroot:latest"
                 },
                 "exposeDockerSocket": True,
-                "env": [{
-                    "name": "ATOMIC_REACTOR_PLUGINS",
-                    "value": "TBD"
-                }]
+                "env": []
             }
         },
         "output": {


### PR DESCRIPTION
* CLOUDBLD-99

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
