### PR TITLE
Fix test.sh breakage for Cent7xPy2...

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -71,14 +71,8 @@ function setup_osbs() {
     $RUN mkdir -p /usr/local/lib/python3.6/site-packages/
   fi
 
-  # CentOS needs to have setuptools updates to use wildcards in requirements.txt and to make pytest-cov work
-  if [[ $OS != "fedora" ]]; then
-    $RUN $PIP install -U setuptools
-
-    # Watch out for https://github.com/pypa/setuptools/issues/937
-    $RUN curl -O https://bootstrap.pypa.io/2.6/get-pip.py
-    $RUN $PYTHON get-pip.py
-  fi
+  $RUN $PIP install -U pip
+  $RUN $PIP install -U setuptools
   $RUN $PYTHON setup.py install
 
   # Install packages for tests


### PR DESCRIPTION
...due to setuptools dropping Py2 support

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
