### PR TITLE
Add the "remote_source.packages" key to the JSON schema

### DIFF
--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -106,6 +106,24 @@
                         "enable-party-popper"
                       ]
                   }
+                },
+                "packages": {
+                  "description": "the packages object to pass to the Cachito request",
+                  "type": ["object", "null"],
+                  "examples": [
+                    {"npm": [{"path": "client"}, {"path": "proxy"}]}
+                  ],
+                  "additionalProperties" : {
+                    "type" : "array",
+                    "items": {
+                      "type": "object",
+                      "examples": [
+                        {"path": "client"},
+                        {"path": "proxy"}
+                      ],
+                      "minProperties": 1
+                    }
+                  }
                 }
               },
               "additionalProperties": false,


### PR DESCRIPTION
This is to support forwarding new parameters to Cachito to
support multiple packages in a single source repository.

Relates to CLOUDBLD-1598

Signed-off-by: mprahl <mprahl@users.noreply.github.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
