### PR TITLE
Build only content sets used just for building content

### DIFF
--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -268,6 +268,21 @@
                 "rhel-8.2.1-modules"
               ]
           }
+        },
+        "build_only_content_sets": {
+          "desription": "Content sets used only for building content, not for distribution",
+          "type": ["object", "null"],
+          "patternProperties": {
+            "^[a-z].*$": {
+              "type": "array",
+              "description": "List of content sets for specific architecture",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "pattern": "^.*-rpms$"
+              }
+            }
+          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
* CLOUDBLD-2046

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
