### PR TITLE
Dont log imagestream and tags before importing, which is polluting bu…

### DIFF
--- a/osbs/core.py
+++ b/osbs/core.py
@@ -973,7 +973,6 @@ class Openshift(object):
 
         # Get the JSON for the ImageStream
         imagestream_json = self.get_image_stream(name).json()
-        logger.debug("imagestream: %r", imagestream_json)
         changed = False
 
         # existence of dockerImageRepository is limiting how many tags are updated
@@ -989,11 +988,7 @@ class Openshift(object):
                 changed = True
 
         if changed:
-            imagestream_json = self.update_image_stream(name, imagestream_json).json()
-
-        # Note the tags before import
-        oldtags = imagestream_json.get('status', {}).get('tags', [])
-        logger.debug("tags before import: %r", oldtags)
+            self.update_image_stream(name, imagestream_json)
 
         stream_import['metadata']['name'] = name
         stream_import['spec']['images'] = []


### PR DESCRIPTION
…ild logs

* CLOUDBLD-2261

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
