### PR TITLE
[markdown] Use older version of mdl (0.9)

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -99,7 +99,7 @@ case ${ACTION} in
   TEST_CMD="bandit-baseline -r osbs -ll -ii"
   ;;
 "markdownlint")
-  $RUN gem install mdl
+  $RUN gem install "mdl:0.9"
   TEST_CMD="mdl -g ."
   ;;
 *)


### PR DESCRIPTION
https://github.com/markdownlint/markdownlint/issues/341

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
