### PR TITLE
Fix ImageName repr()

### DIFF
--- a/osbs/utils/__init__.py
+++ b/osbs/utils/__init__.py
@@ -689,7 +689,10 @@ class ImageName(object):
         return self.to_str(registry=True, tag=True)
 
     def __repr__(self):
-        return "ImageName(image=%r)" % self.to_str()
+        return (
+            "ImageName(registry={s.registry!r}, namespace={s.namespace!r},"
+            " repo={s.repo!r}, tag={s.tag!r})"
+        ).format(s=self)
 
     def __eq__(self, other):
         return (type(self) == type(other) and    # pylint: disable=unidiomatic-typecheck


### PR DESCRIPTION
Usually output of repr() can be used to construct object, it's not
possible currently, because `image` is not an argument in init method.

Also is fun to debug following pytest output:
```
ImageName(image='weird-registry/new-bar@sha256:2') != ImageName(image='weird-registry/new-bar@sha256:2')
```
because in reality it was:
```
ImageName(registry='weird-registry', namespace=None, repo='new-bar',
tag='sha256:2') != ImageName(registry=None, namespace='weird-registry',
repo='new-bar', tag='sha256:2')
```

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
