### PR TITLE
Unpin 'jsonschema' to allow version from RHEL 8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dockerfile-parse
-jsonschema==2.3.0  # to match available in RHEL/CentOS 7
+jsonschema
 requests
 requests-kerberos
 six


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

* CLOUDBLD-1877

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
