### PR TITLE
Separate py2/py3 deps

### DIFF
--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,0 +1,6 @@
+dockerfile-parse
+jsonschema==2.3.0  # to match available in RHEL/CentOS 7
+requests
+requests-kerberos
+six
+PyYAML

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,1 +1,0 @@
-python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+python-dateutil
 dockerfile-parse
-jsonschema==2.3.0  # to match available in RHEL/CentOS 7
+jsonschema
 requests
 requests-kerberos
 six

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,10 @@ def _get_requirements(path):
     return [p.strip() for p in packages if not re.match(r"^\s*#", p)]
 
 def _install_requirements():
-    requirements = _get_requirements('requirements.txt')
     if sys.version_info[0] >= 3:
-        requirements += _get_requirements('requirements-py3.txt')
+        requirements = _get_requirements('requirements.txt')
+    else:
+        requirements = _get_requirements('requirements-py2.txt')
     return requirements
 
 setup(

--- a/test.sh
+++ b/test.sh
@@ -77,7 +77,6 @@ function setup_osbs() {
 
   # Install packages for tests
   $RUN $PIP install -r tests/requirements.txt
-  if [[ $PYTHON_VERSION -gt 2 ]]; then $RUN $PIP install -r requirements-py3.txt; fi
 }
 
 case ${ACTION} in


### PR DESCRIPTION
py2 and py3 diverges we have to keep separated requirement files.

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
