### PR TITLE
HttpStream: fix close method

### DIFF
--- a/osbs/http.py
+++ b/osbs/http.py
@@ -188,11 +188,12 @@ class HttpStream(object):
             return
 
     def close(self):
-        if not self.closed:
+        # using getattr and hasattr because this may be called from __del__
+        if not getattr(self, 'closed', True):
             logger.debug("cleaning up")
             if hasattr(self, 'req'):
                 del self.req
-        self.closed = True
+            self.closed = True
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
`.close()` is called from `__del__` and because this happend during
garbage collecting nothing is guaranted [1] and it results into following
traceback printed directly to stderr because it happened in GC context:
```
Traceback (most recent call last):
  File "/home/mbasti/repos-upstream/osbs-client/osbs/http.py", line 221, in __del__
    self.close()
  File "/home/mbasti/repos-upstream/osbs-client/osbs/http.py", line 214, in close
    if not self.closed:
AttributeError: 'HttpStream' object has no attribute 'closed'
```

Using getattr instead to avoid traceback.

TLDR: use context managers if you want to be sure that connection is closed
properly.

[1] https://docs.python.org/3/reference/datamodel.html#object.__del__

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
