### PR TITLE
Travis: Enable F32 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
       ENGINE=docker
     - ACTION=bandit
       OS=fedora
-      OS_VERSION=31
+      OS_VERSION=32
       PYTHON_VERSION=3
       ENGINE=docker
     - ACTION=pylint
@@ -24,7 +24,7 @@ env:
       ENGINE=docker
     - ACTION=pylint
       OS=fedora
-      OS_VERSION=31
+      OS_VERSION=32
       PYTHON_VERSION=3
       ENGINE=docker
     - OS=centos
@@ -32,7 +32,7 @@ env:
       PYTHON_VERSION=2
       ENGINE=docker
     - OS=fedora
-      OS_VERSION=30
+      OS_VERSION=32
       PYTHON_VERSION=3
       ENGINE=docker
     - OS=fedora

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -16,7 +16,7 @@ import datetime
 import re
 import sys
 import requests
-from time import tzset
+from time import tzset, sleep
 from pkg_resources import parse_version
 from textwrap import dedent
 
@@ -544,6 +544,7 @@ def initialize_git_repo(rpath, files=None):
         subprocess.Popen(['git', 'add', f], cwd=rpath)
         subprocess.Popen(['git', 'commit', '-m', 'new file {0}'.format(f)], cwd=rpath)
         if not first_commit_ref:
+            sleep(2)  # when rev-parse is called too early after first commit, it fails
             first_commit_ref = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=rpath)
             first_commit_ref = first_commit_ref.strip()
     subprocess.Popen(['git', 'commit', '--allow-empty', '-m', 'code additions'], cwd=rpath)


### PR DESCRIPTION
* Use latest fedora for testing
* Remove EOL Fedora 30
* Seems that new git/fedora has a time constrains when repo cannot be
  instantly used

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
