### PR TITLE
api.py: Catch mismatches between the flatpak parameter and the repo

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -756,6 +756,17 @@ class OSBS(object):
 
         repo_info = utils.get_repo_info(git_uri, git_ref, git_branch=git_branch,
                                         depth=git_commit_depth)
+
+        if flatpak and not repo_info.configuration.is_flatpak:
+            raise OsbsException(
+                "Flatpak build, "
+                "but repository doesn't have a container.yaml with a flatpak: section")
+
+        if not flatpak and repo_info.configuration.is_flatpak:
+            raise OsbsException(
+                "Not a flatpak build, "
+                "but repository has a container.yaml with a flatpak: section")
+
         req_labels = self._check_labels(repo_info)
 
         user_params = self.get_user_params(base_image=repo_info.base_image,

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -114,7 +114,8 @@ class ArrangementBase(object):
     ORCHESTRATOR_ADD_PARAMS = {}
     WORKER_ADD_PARAMS = {}
 
-    def mock_env(self, base_image='fedora23/python', additional_tags=None):
+    def mock_env(self, base_image='fedora23/python', additional_tags=None,
+                 flatpak=False):
         class MockParser(object):
             labels = {
                 'name': 'fedora23/something',
@@ -135,7 +136,7 @@ class ArrangementBase(object):
                 self.module = self.container['compose']['modules'][0]
                 self.container_module_specs = [ModuleSpec.from_str(self.module)]
                 self.depth = int(depth) if depth else 0
-                self.is_flatpak = False
+                self.is_flatpak = flatpak
                 self.flatpak_base_image = None
                 self.flatpak_component = None
                 self.flatpak_name = None
@@ -193,7 +194,8 @@ class ArrangementBase(object):
                           additional_params=None):
         base_image = additional_params.pop('base_image', None)
         self.mock_env(base_image=base_image,
-                      additional_tags=additional_params.get('additional_tags'))
+                      additional_tags=additional_params.get('additional_tags'),
+                      flatpak=additional_params.get('flatpak'))
         params = self.COMMON_PARAMS.copy()
         assert build_type in ('orchestrator', 'worker',
                               'source_container')


### PR DESCRIPTION
If a build is started with the 'flatpak' parameter, but doesn't have a
container.yaml with a 'flatpak' section, or a build is started without
the 'flatpak' parameter, but has a Flatpak container.yaml, the user
would get super-confusing failures, since the repo-parsing part of the code is
independent of the part of the code that checks for build type.

Check for consistency, and throw helpful messages.

Signed-off-by: Owen W. Taylor <otaylor@fishsoup.net>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
