### PR TITLE
Use newer version fedora image in CI

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -23,7 +23,7 @@ jobs:
             engine: docker
 
           - name: fedora
-            version: 32
+            version: 33
             python: 3
             engine: docker
 
@@ -73,7 +73,7 @@ jobs:
             engine: docker
 
           - name: fedora
-            version: 32
+            version: 33
             python: 3
             engine: docker
 

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -23,12 +23,12 @@ jobs:
             engine: docker
 
           - name: fedora
-            version: 31
+            version: 32
             python: 3
             engine: docker
 
           - name: fedora
-            version: 32
+            version: 33
             python: 3
             engine: docker
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -53,7 +53,8 @@ disable=I,
         unused-argument,  # nice to have
         useless-else-on-loop,
         wrong-import-order,
-        wrong-import-position
+        wrong-import-position,
+        raise-missing-from  # nice to have, but has to work with Python 2
 
 [REPORTS]
 

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -249,6 +249,7 @@ class BuildCommon(BuildParamsBase):
 
     def validate(self):
         logger.info("Validating params of %s", self.__class__.__name__)
+        # pylint: disable=not-an-iterable; pylint does not understand metaclass properties
         missing = [p for p in self.__class__.required_params if p.__get__(self) is None]
         if missing:
             missing_repr = ", ".join(repr(p.name) for p in missing)
@@ -276,6 +277,7 @@ class BuildCommon(BuildParamsBase):
         return retdict
 
     def to_json(self):
+        # pylint: disable=not-an-iterable; pylint does not understand metaclass properties
         keys = (p.name for p in self.__class__.params if p.include_in_json)
         json_dict = self.to_dict(keys)
         json_dict[KIND_KEY] = self.KIND


### PR DESCRIPTION
* CLOUDBLD-3581

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
