### PR TITLE
New option --operator-csv-modifications-url

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -791,10 +791,6 @@ class OSBS(object):
                                                repo_info=repo_info)
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
 
-        if isolated:
-            if build_request.is_from_scratch_image():
-                raise ValueError('"FROM scratch" image build cannot be isolated')
-
         builds_for_koji_task = []
         if koji_task_id and build_type == BUILD_TYPE_ORCHESTRATOR:
             # try to find build for koji_task which isn't canceled and use that one

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -733,6 +733,7 @@ class OSBS(object):
                               isolated=None,
                               koji_task_id=None,
                               target=None,
+                              operator_csv_modifications_url=None,
                               **kwargs):
 
         required_params = {"git_uri": git_uri, "git_ref": git_ref, "git_branch": git_branch}
@@ -766,6 +767,9 @@ class OSBS(object):
             raise OsbsException(
                 "Not a flatpak build, "
                 "but repository has a container.yaml with a flatpak: section")
+
+        if operator_csv_modifications_url and not isolated:
+            raise OsbsException('Only isolated build can update operator CSV metadata')
 
         req_labels = self._check_labels(repo_info)
 

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -327,9 +327,16 @@ class PluginsConfigurationBase(object):
         name = 'pin_operator_digest'
 
         replacement_pullspecs = self.user_params.operator_bundle_replacement_pullspecs
+        modifications_url = self.user_params.operator_csv_modifications_url
 
-        if replacement_pullspecs and self.pt.has_plugin_conf(phase, name):
-            self.pt.set_plugin_arg(phase, name, 'replacement_pullspecs', replacement_pullspecs)
+        if self.pt.has_plugin_conf(phase, name):
+            if replacement_pullspecs:
+                self.pt.set_plugin_arg(phase, name, 'replacement_pullspecs', replacement_pullspecs)
+
+            if modifications_url:
+                self.pt.set_plugin_arg(
+                    phase, name, 'operator_csv_modifications_url', modifications_url
+                )
 
     def render_export_operator_manifests(self):
         phase = 'postbuild_plugins'

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -309,6 +309,7 @@ class BuildUserParams(BuildCommon):
     koji_upload_dir = BuildParam("koji_upload_dir")
     name = BuildIDParam()
     operator_bundle_replacement_pullspecs = BuildParam("operator_bundle_replacement_pullspecs")
+    operator_csv_modifications_url = BuildParam("operator_csv_modifications_url")
     operator_manifests_extract_platform = BuildParam("operator_manifests_extract_platform")
     parent_images_digests = BuildParam("parent_images_digests")
     platforms = BuildParam("platforms")
@@ -355,6 +356,7 @@ class BuildUserParams(BuildCommon):
                     koji_upload_dir=None,
                     name_label=None,
                     operator_bundle_replacement_pullspecs=None,
+                    operator_csv_modifications_url=None,
                     operator_manifests_extract_platform=None,
                     parent_images_digests=None,
                     platform=None,
@@ -400,6 +402,7 @@ class BuildUserParams(BuildCommon):
         :param operator_bundle_replacement_pullspecs: dict, mapping of original pullspecs to
                                                       replacement pullspecs for operator manifest
                                                       bundle builds
+        :param operator_csv_modifications_url: str, URL to JSON file describing operator CSV changes
         :param operator_manifests_extract_platform: str, indicates which platform should upload
                                                     operator manifests to koji
         :param parent_images_digests: dict, mapping image digests to names and platforms
@@ -479,6 +482,7 @@ class BuildUserParams(BuildCommon):
             "koji_parent_build": koji_parent_build,
             "koji_upload_dir": koji_upload_dir,
             "operator_bundle_replacement_pullspecs": operator_bundle_replacement_pullspecs,
+            "operator_csv_modifications_url": operator_csv_modifications_url,
             "operator_manifests_extract_platform": operator_manifests_extract_platform,
             "parent_images_digests": parent_images_digests,
             "platform": platform,

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -355,6 +355,7 @@ def cmd_build(args, osbs):
         'signing_intent': args.signing_intent,
         'compose_ids': args.compose_ids,
         'skip_build': args.skip_build,
+        'operator_csv_modifications_url': args.operator_csv_modifications_url,
     }
     if args.arrangement_version:
         if args.arrangement_version < 6:
@@ -733,6 +734,9 @@ def cli():
                               metavar="pkg_manager:name:version[:new_name]",
                               dest="dependency_replacements",
                               help="Cachito dependency replacement")
+    build_parser.add_argument("--operator-csv-modifications-url", action='store', required=False,
+                              dest='operator_csv_modifications_url', metavar='URL',
+                              help="URL to JSON file with operator CSV modification")
 
     build_source_container_parser = subparsers.add_parser(
         str_on_2_unicode_on_3('build-source-container'),
@@ -928,6 +932,10 @@ def cli():
                 "at least one of --sources-for-koji-build-id and "
                 "--sources-for-koji-build-nvr has to be specified"
             )
+
+    if getattr(args, 'func', None) is cmd_build:
+        if args.operator_csv_modifications_url and not args.isolated:
+            parser.error("Only --isolated builds support option --operator-csv-modifications-url")
 
     return parser, args
 

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -754,25 +754,34 @@ class TestPluginsConfiguration(object):
         assert plugin_value_get(plugins, plugin_type, plugin_name, 'args',
                                 'koji_parent_build') == parent_value
 
-    def test_render_pin_operator_digest(self):
+    @pytest.mark.parametrize('param,param_render,value', [
+        (
+            'operator_bundle_replacement_pullspecs',
+            'replacement_pullspecs',
+            {'foo/fedora:30': 'bar/fedora@sha256:deadbeef'},
+        ),
+        (
+            'operator_csv_modifications_url',
+            'operator_csv_modifications_url',
+            'https://example.com/test.json',
+        ),
+    ])
+    def test_render_pin_operator_digest(self, param, param_render, value):
         plugin_type = "prebuild_plugins"
         plugin_name = "pin_operator_digest"
 
-        replacement_pullspecs = {
-            'foo/fedora:30': 'bar/fedora@sha256:deadbeef'
-        }
-        extra_args = {
-            'operator_bundle_replacement_pullspecs': replacement_pullspecs
-        }
+        extra_args = {param: value}
 
         self.mock_repo_info()
         user_params = get_sample_user_params(extra_args=extra_args)
         build_json = PluginsConfiguration(user_params).render()
         plugins = get_plugins_from_build_json(build_json)
 
-        plugin_value = plugin_value_get(plugins, plugin_type, plugin_name,
-                                        'args', 'replacement_pullspecs')
-        assert plugin_value == replacement_pullspecs
+        plugin_value = plugin_value_get(
+            plugins, plugin_type, plugin_name,
+            'args', param_render
+        )
+        assert plugin_value == value
 
     @pytest.mark.parametrize('extract_platform', ('x86_64', 'aarch64'))
     @pytest.mark.parametrize('build_type', (BUILD_TYPE_WORKER, BUILD_TYPE_ORCHESTRATOR))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3213,52 +3213,6 @@ class TestOSBS(object):
             osbs.create_build(target=TEST_TARGET, **required_args)
         assert exc_msg in str(exc.value)
 
-    def test_do_create_prod_build_isolated_from_scratch(self, osbs):  # noqa
-        inner_template = DEFAULT_INNER_TEMPLATE
-        outer_template = DEFAULT_OUTER_TEMPLATE
-        customize_conf = DEFAULT_CUSTOMIZE_CONF
-        repo_info = self.mock_repo_info(mock_df_parser=MockDfParserFromScratch())
-
-        user_params = BuildUserParams.make_params(
-            build_json_dir=osbs.os_conf.get_build_json_store(),
-            base_image='scratch',
-            build_from='image:python',
-            build_conf=osbs.build_conf,
-            name_label='scratch',
-            repo_info=repo_info,
-            user=TEST_USER,
-            isolated=True,
-            build_type=BUILD_TYPE_ORCHESTRATOR,
-            release='0.1'
-        )
-
-        (flexmock(utils)
-            .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
-            .and_return(repo_info))
-
-        (flexmock(osbs)
-            .should_receive('get_user_params')
-            .and_return(user_params))
-
-        (flexmock(osbs)
-            .should_call('get_build_request')
-            .with_args(inner_template=inner_template,
-                       outer_template=outer_template,
-                       customize_conf=customize_conf,
-                       user_params=user_params,
-                       repo_info=repo_info)
-            .once())
-
-        with pytest.raises(ValueError) as exc:
-            osbs._do_create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
-                                       TEST_GIT_BRANCH, user=TEST_USER,
-                                       inner_template=inner_template,
-                                       outer_template=outer_template,
-                                       customize_conf=customize_conf,
-                                       isolated=True)
-        assert '"FROM scratch" image build cannot be isolated' in str(exc.value)
-
     @pytest.mark.parametrize(('flatpak'), (True, False))  # noqa
     def test_do_create_prod_build_no_dockerfile(self, osbs, flatpak, tmpdir):
         class MockDfParserNoDf(object):


### PR DESCRIPTION
Option can pass URL to JSON file with modifications to operator CSV
file.

Can be used only with --isolated option

* CLOUDBLD-3976

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [waived] Pull request has a link to an osbs-docs PR for user documentation updates
