### PR TITLE
Fix: pass operator_csv_modifications_url param to userparams

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -773,16 +773,18 @@ class OSBS(object):
 
         req_labels = self._check_labels(repo_info)
 
-        user_params = self.get_user_params(base_image=repo_info.base_image,
-                                           build_type=build_type,
-                                           component=component,
-                                           flatpak=flatpak,
-                                           isolated=isolated,
-                                           koji_target=target,
-                                           koji_task_id=koji_task_id,
-                                           req_labels=req_labels,
-                                           repo_info=repo_info,
-                                           **kwargs)
+        user_params = self.get_user_params(
+            base_image=repo_info.base_image,
+            build_type=build_type,
+            component=component,
+            flatpak=flatpak,
+            isolated=isolated,
+            koji_target=target,
+            koji_task_id=koji_task_id,
+            req_labels=req_labels,
+            repo_info=repo_info,
+            operator_csv_modifications_url=operator_csv_modifications_url,
+            **kwargs)
 
         build_request = self.get_build_request(inner_template=inner_template,
                                                outer_template=outer_template,


### PR DESCRIPTION
operator_csv_modifications_url option was not passed to user params at
client side

* CLOUDBLD-3976

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
