### PR TITLE
add generate_maven_metadata post plugin

### DIFF
--- a/inputs/orchestrator_inner:6.json
+++ b/inputs/orchestrator_inner:6.json
@@ -84,6 +84,9 @@
     },
     {
       "name": "push_operator_manifests"
+    },
+    {
+      "name": "generate_maven_metadata"
     }
   ],
   "prepublish_plugins": [],

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -61,6 +61,7 @@ PLUGIN_RESOLVE_COMPOSES_KEY = 'resolve_composes'
 PLUGIN_VERIFY_MEDIA_KEY = 'verify_media'
 PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY = 'export_operator_manifests'
 PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY = 'push_operator_manifests'
+PLUGIN_GENERATE_MAVEN_METADATA_KEY = 'generate_maven_metadata'
 
 
 class NoSuchPluginException(Exception):
@@ -309,6 +310,7 @@ class TestArrangementV6(ArrangementBase):
                 'tag_from_config',
                 PLUGIN_GROUP_MANIFESTS_KEY,
                 PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY,
+                PLUGIN_GENERATE_MAVEN_METADATA_KEY,
             ],
 
             'exit_plugins': [


### PR DESCRIPTION
This plugin will run on orchestrator to collect maven metadata
from fetch-artifacts-koji and fetch-artifacts-url files

This is an accompanying change for https://github.com/containerbuildsystem/atomic-reactor/pull/1602

Main epic - MMENG-829
Story - MMENG-1275

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
