### PR TITLE
Print user warnings to osbs-client command line output

### DIFF
--- a/osbs/__init__.py
+++ b/osbs/__init__.py
@@ -9,14 +9,14 @@ from __future__ import print_function, absolute_import, unicode_literals
 
 import logging
 
-from osbs.constants import USER_WARNING_LEVEL
+from osbs.constants import USER_WARNING_LEVEL, USER_WARNING_LEVEL_NAME
 from osbs.utils import user_warning_log_handler
 from osbs.version import __version__  # noqa
 
 
 def set_logging(name="osbs", level=logging.DEBUG):
     # add new level to loggers
-    logging.addLevelName(USER_WARNING_LEVEL, "USER_WARNING")
+    logging.addLevelName(USER_WARNING_LEVEL, USER_WARNING_LEVEL_NAME)
     logging.Logger.user_warning = user_warning_log_handler
 
     # create logger

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -79,6 +79,7 @@ ATOMIC_REACTOR_LOGGING_FMT = \
 # Numeric representation of user warnings loggers' level
 # User warning level is logically between INFO (20) and WARNING (30) levels
 USER_WARNING_LEVEL = 25
+USER_WARNING_LEVEL_NAME = 'USER_WARNING'
 
 REPO_CONFIG_FILE = '.osbs-repo-config'
 ADDITIONAL_TAGS_FILE = 'additional-tags'


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
