### PR TITLE
User warnings handler requires positional arguments

### DIFF
--- a/osbs/utils/__init__.py
+++ b/osbs/utils/__init__.py
@@ -601,7 +601,7 @@ def user_warning_log_handler(self, message):
         'message': message,
     }
     msg = json.dumps(content)
-    self._log(USER_WARNING_LEVEL, msg)
+    self._log(USER_WARNING_LEVEL, msg, None)
 
 
 class RetryFunc(object):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -618,7 +618,7 @@ def test_image_name_comparison():
     (11, None)
 ))
 def test_user_warnings_handler(message, expected):
-    def mocked_log(level, message):
+    def mocked_log(level, message, args):
         assert level == USER_WARNING_LEVEL
         assert message == expected
 


### PR DESCRIPTION
*CLOUDBLD-4640

Signed-off-by: Serhii Salatskyi <ssalatsk@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
