### PR TITLE
Update user parameters related to remote sources

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -192,8 +192,8 @@ class PluginsConfigurationBase(object):
         phase = 'prebuild_plugins'
         plugin = 'add_image_content_manifest'
         if self.pt.has_plugin_conf(phase, plugin):
-            self.pt.set_plugin_arg_valid(phase, plugin, 'remote_source_icm_url',
-                                         self.user_params.remote_source_icm_url)
+            self.pt.set_plugin_arg_valid(phase, plugin, 'remote_sources',
+                                         self.user_params.remote_sources)
 
     def render_add_labels_in_dockerfile(self):
         phase = 'prebuild_plugins'
@@ -499,12 +499,8 @@ class PluginsConfigurationBase(object):
         plugin = 'download_remote_source'
 
         if self.pt.has_plugin_conf(phase, plugin):
-            self.pt.set_plugin_arg(phase, plugin, 'remote_source_url',
-                                   self.user_params.remote_source_url)
-            self.pt.set_plugin_arg(phase, plugin, 'remote_source_build_args',
-                                   self.user_params.remote_source_build_args)
-            self.pt.set_plugin_arg(phase, plugin, 'remote_source_configs',
-                                   self.user_params.remote_source_configs)
+            self.pt.set_plugin_arg(phase, plugin, 'remote_sources',
+                                   self.user_params.remote_sources)
 
     def render_resolve_remote_source(self):
         phase = 'prebuild_plugins'

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -314,10 +314,7 @@ class BuildUserParams(BuildCommon):
     parent_images_digests = BuildParam("parent_images_digests")
     platforms = BuildParam("platforms")
     release = BuildParam("release")
-    remote_source_build_args = BuildParam("remote_source_build_args")
-    remote_source_configs = BuildParam("remote_source_configs")
-    remote_source_icm_url = BuildParam("remote_source_icm_url")
-    remote_source_url = BuildParam("remote_source_url")
+    remote_sources = BuildParam("remote_sources")
     skip_build = BuildParam("skip_build")
     tags_from_yaml = BuildParam("tags_from_yaml")
     trigger_imagestreamtag = BuildParam("trigger_imagestreamtag")
@@ -362,10 +359,7 @@ class BuildUserParams(BuildCommon):
                     platform=None,
                     platforms=None,
                     release=None,
-                    remote_source_build_args=None,
-                    remote_source_configs=None,
-                    remote_source_icm_url=None,
-                    remote_source_url=None,
+                    remote_sources=None,
                     repo_info=None,
                     skip_build=None,
                     tags_from_yaml=None,
@@ -413,12 +407,15 @@ class BuildUserParams(BuildCommon):
         an environment variable into a worker build;
         when used, reactor_config_map is ignored.
         :param release: str,
-        :param remote_source_build_args: dict, extra args for `builder.build_args`, if any
-        :param remote_source_configs: list of str, configuration files to be injected into
-        the exploded remote sources dir
-        :param remote_source_icm_url: int, the Cachito ICM URL; used to request the
-        Image Content Manifest
-        :param remote_source_url: str, URL from which to download a source archive
+        :param remote_sources: list of dicts, each dict contains info about particular
+        remote source with the following keys:
+            build_args: dict, extra args for `builder.build_args`, if any
+            configs: list of str, configuration files to be injected into
+            the exploded remote sources dir
+            request_id: int, cachito request id; used to request the
+            Image Content Manifest
+            url: str, URL from which to download a source archive
+            name: str, name of remote source
         :param repo_info: RepoInfo, git repo data for the build
         :param scratch: bool, build as a scratch build
         :param signing_intent: bool, True to sign the resulting image
@@ -488,10 +485,7 @@ class BuildUserParams(BuildCommon):
             "platform": platform,
             "platforms": platforms,
             "release": release,
-            "remote_source_build_args": remote_source_build_args,
-            "remote_source_configs": remote_source_configs,
-            "remote_source_icm_url": remote_source_icm_url,
-            "remote_source_url": remote_source_url,
+            "remote_sources": remote_sources,
             "skip_build": skip_build,
             "trigger_imagestreamtag": base_image,
             "triggered_after_koji_task": triggered_after_koji_task,


### PR DESCRIPTION
CLOUDBLD-4449

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
