### PR TITLE
User warnings can return list of warnings

### DIFF
--- a/osbs/utils/__init__.py
+++ b/osbs/utils/__init__.py
@@ -759,6 +759,10 @@ class UserWarningsStore(object):
 
         self._user_warnings.add(message)
 
+    def __iter__(self):
+        for user_warning in self._user_warnings:
+            yield user_warning
+
     def __str__(self):
         return '\n'.join(self._user_warnings)
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -636,7 +636,7 @@ def test_user_warnings_handler(message, expected, caplog):
         '2021-03-18 23:35:42,573 - osbs.http - USER_WARNING - load info',
         '2021-03-18 23:35:42,573 - osbs.http - USER_WARNING - {"asd112}',
         '2021-03-18 23:35:42,573 - osbs.http - DEBUG - {"message": "foo-bar"}',
-     ), [""], ['{"asd112}']),
+     ), [], ['{"asd112}']),
     ((
         '2021-03-22 23:35:44,573 platform:x86_64 - atomic_reactor.inner - '
         'USER_WARNING - {"message": "foo-bar"}',
@@ -661,5 +661,7 @@ def test_store_user_warnings(logs, expected, wrong_input, caplog):
             message = 'Incorrect JSON data input for a user warning: {}'
             assert message.format(input_) in caplog.text
 
-    user_warnings = str(user_warnings).split('\n')
+    assert sorted(user_warnings) == sorted(expected)
+
+    user_warnings = str(user_warnings).splitlines()
     assert sorted(user_warnings) == sorted(expected)


### PR DESCRIPTION
*CLOUDBLD-4643

Signed-off-by: Serhii Salatskyi <ssalatsk@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
