### PR TITLE
No more TODOs and FIXME in code

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,6 @@ disable=I,
         broad-except,
         comprehension-escape, # throws false positives on 1.9.0 (Fedora 29)
         exception-escape, # throws false positives on 1.9.0 (Fedora 29)
-        fixme,
         import-outside-toplevel,
         invalid-name,
         keyword-arg-before-vararg,  # nice to have

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -63,7 +63,6 @@ from six.moves import http_client, input
 def osbsapi(func):
     @wraps(func)
     def catch_exceptions(*args, **kwargs):
-        # XXX: remove this in the future
         if kwargs.pop("namespace", None):
             warnings.warn("OSBS.%s: the 'namespace' argument is no longer supported" %
                           func.__name__)

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -616,8 +616,6 @@ def cli():
         description="OpenShift Build Service client"
     )
     exclusive_group = parser.add_mutually_exclusive_group()
-    # FIXME: default=None is needed to indicate for osbs.conf.Configuration
-    # that the option was not specified
     exclusive_group.add_argument("--verbose", action="store_true", default=None)
     exclusive_group.add_argument("-q", "--quiet", action="store_true")
     exclusive_group.add_argument("-V", "--version", action="version", version=version)

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -62,7 +62,6 @@ class Configuration(object):
 
     def _get_value(self, args_key, conf_section, conf_key, default=None, is_bool_val=False,
                    deprecated=False):
-        # FIXME: this is too bloated: split it into separate classes
         # and implement it as mixins
         def get_value_from_kwargs():
             return self.kwargs.get(args_key)

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -37,7 +37,6 @@ POD_SUCCEEDED_STATES = ["succeeded"]
 POD_RUNNING_STATES = ["pending", "running"]
 # https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/api/types.go
 # type PodPhase string
-# fixme: what about "unknown" state?
 BUILD_CANCELLED_STATE = "cancelled"
 BUILD_FINISHED_STATES = ["failed", "complete", "error", BUILD_CANCELLED_STATE]
 BUILD_FAILED_STATES = ["failed", "error", "cancelled"]  # meaning no image produced

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -68,7 +68,6 @@ def check_response(response, log_level=logging.ERROR):
         raise OsbsResponseException(message=content, status_code=response.status_code)
 
 
-# TODO: error handling: create function which handles errors in response object
 class Openshift(object):
     def __init__(self, openshift_api_url, openshift_oauth_url,
                  k8s_api_url=None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -278,7 +278,7 @@ class TestOSBS(object):
     # osbs is a fixture here
     @pytest.mark.parametrize('name_label_name', ['Name', 'name'])  # noqa
     def test_create_build(self, osbs, name_label_name):
-        # TODO: test situation when a buildconfig already exists
+
         class MockParser(object):
             labels = {
                 name_label_name: 'fedora23/something',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -523,7 +523,6 @@ class TestOpenshift(object):
         openshift.put_image_stream_tag(tag_id, mock_data)
 
     def _make_tag_template(self):
-        # TODO: Just read from inputs folder
         return json.loads(dedent('''\
             {
               "kind": "ImageStreamTag",


### PR DESCRIPTION
TODOs should be resolved before merging or issue trackers should be used
instead.

No one ever will go and fix TODOs, mainly if half of them is not valid
because code changes.

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
