### PR TITLE
UserWarningStore returns correct boolean value for PY2 version

### DIFF
--- a/osbs/utils/__init__.py
+++ b/osbs/utils/__init__.py
@@ -766,5 +766,8 @@ class UserWarningsStore(object):
     def __str__(self):
         return '\n'.join(self._user_warnings)
 
+    def __len__(self):
+        return len(self._user_warnings)
+
     def __bool__(self):
         return bool(self._user_warnings)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -661,6 +661,8 @@ def test_store_user_warnings(logs, expected, wrong_input, caplog):
             message = 'Incorrect JSON data input for a user warning: {}'
             assert message.format(input_) in caplog.text
 
+    assert bool(user_warnings) == bool(expected)
+    assert len(user_warnings) == len(expected)
     assert sorted(user_warnings) == sorted(expected)
 
     user_warnings = str(user_warnings).splitlines()


### PR DESCRIPTION
*CLOUDBLD-4643

Signed-off-by: Serhii Salatskyi <ssalatsk@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
