### PR TITLE
Make sure that annotations are string

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -54,7 +54,8 @@ from osbs.exceptions import (OsbsException, OsbsValidationException, OsbsRespons
 from osbs.utils.labels import Labels
 # import utils in this way, so that we can mock standalone functions with flexmock
 from osbs import utils
-from osbs.utils import (retry_on_conflict, graceful_chain_get, RegistryURI, ImageName)
+from osbs.utils import (retry_on_conflict, graceful_chain_get, RegistryURI, ImageName,
+                        stringify_values)
 
 from six.moves import http_client, input
 
@@ -1099,10 +1100,16 @@ class OSBS(object):
 
     @osbsapi
     def update_annotations_on_build(self, build_id, annotations):
+        # annotations support only string, make sure it's string
+        # or json serializable object
+        annotations = stringify_values(annotations)
         return self.os.update_annotations_on_build(build_id, annotations)
 
     @osbsapi
     def set_annotations_on_build(self, build_id, annotations):
+        # annotations support only string, make sure it's string
+        # or json serializable object
+        annotations = stringify_values(annotations)
         return self.os.set_annotations_on_build(build_id, annotations)
 
     @osbsapi

--- a/osbs/utils/__init__.py
+++ b/osbs/utils/__init__.py
@@ -771,3 +771,19 @@ class UserWarningsStore(object):
 
     def __bool__(self):
         return bool(self._user_warnings)
+
+
+def stringify_values(d):
+    """All non-string values in dictionary will be json serialized.
+
+    Example of usage is for openshift annotations which must be strings only.
+
+    :param dict d: dict with values of various types
+    :return: new dict with values converted to string
+    """
+    assert isinstance(d, dict)
+
+    return {
+        k: val if isinstance(val, str) else json.dumps(val)
+        for k, val in d.items()
+    }

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -27,7 +27,8 @@ from osbs.utils import (buildconfig_update,
                         git_repo_humanish_part_from_uri, sanitize_strings_for_openshift,
                         get_time_from_rfc3339, TarWriter, TarReader, make_name_from_git,
                         wrap_name_from_git, get_instance_token_file_name, sanitize_version,
-                        has_triggers, clone_git_repo, get_repo_info, UserWarningsStore, ImageName)
+                        has_triggers, clone_git_repo, get_repo_info, UserWarningsStore, ImageName,
+                        stringify_values)
 from osbs.exceptions import OsbsException, OsbsCommitNotFound
 from tests.constants import (TEST_DOCKERFILE_GIT, TEST_DOCKERFILE_SHA1, TEST_DOCKERFILE_INIT_SHA1,
                              TEST_DOCKERFILE_BRANCH)
@@ -667,3 +668,13 @@ def test_store_user_warnings(logs, expected, wrong_input, caplog):
 
     user_warnings = str(user_warnings).splitlines()
     assert sorted(user_warnings) == sorted(expected)
+
+
+@pytest.mark.parametrize('d,expected', (
+    [{}, {}],
+    [{'a': [{}]}, {"a": '[{}]'}],
+    [{'b': 'test'}, {'b': 'test'}],
+    [{'a': 'test', 'b': {'c': 5}}, {'a': 'test', 'b': '{"c": 5}'}],
+))
+def test_stringify_values(d, expected):
+    assert stringify_values(d) == expected


### PR DESCRIPTION
OCP will reject any non-string annotations, make sure values are
converted

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
