### PR TITLE
[ocp3] Wait for subprocess.Popen()

### DIFF
--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -537,19 +537,19 @@ def test_get_repo_info(tmpdir):
 
 
 def initialize_git_repo(rpath, files=None):
-    subprocess.Popen(['git', 'init', rpath])
-    subprocess.Popen(['git', 'config', 'user.name', '"Gerald Host"'], cwd=rpath)
-    subprocess.Popen(['git', 'config', 'user.email', '"ghost@example.com"'], cwd=rpath)
+    subprocess.Popen(['git', 'init', rpath]).wait()
+    subprocess.Popen(['git', 'config', 'user.name', '"Gerald Host"'], cwd=rpath).wait()
+    subprocess.Popen(['git', 'config', 'user.email', '"ghost@example.com"'], cwd=rpath).wait()
     first_commit_ref = None
     for f in files or []:
-        subprocess.Popen(['touch', f], cwd=rpath)
-        subprocess.Popen(['git', 'add', f], cwd=rpath)
-        subprocess.Popen(['git', 'commit', '-m', 'new file {0}'.format(f)], cwd=rpath)
+        subprocess.Popen(['touch', f], cwd=rpath).wait()
+        subprocess.Popen(['git', 'add', f], cwd=rpath).wait()
+        subprocess.Popen(['git', 'commit', '-m', 'new file {0}'.format(f)], cwd=rpath).wait()
         if not first_commit_ref:
             sleep(2)  # when rev-parse is called too early after first commit, it fails
             first_commit_ref = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=rpath)
             first_commit_ref = first_commit_ref.strip()
-    subprocess.Popen(['git', 'commit', '--allow-empty', '-m', 'code additions'], cwd=rpath)
+    subprocess.Popen(['git', 'commit', '--allow-empty', '-m', 'code additions'], cwd=rpath).wait()
     return first_commit_ref
 
 


### PR DESCRIPTION
Popen() doesn't wait until subprocess ends. This causes race-conditions
in git tests. With Popen() .wait() must be called to have deterministic
test.

Fixes: #1028

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
