### PR TITLE
Remove all related to arrangement versions

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -91,8 +91,6 @@ Some options are also mandatory.
   with optional mount path in the format `secret[:path]`, which can be used to
   hold service account tokens referenced by token_file in the osbs_client_secret
   osbs.conf
-- `arrangement_version` (optional, int): default version of inner template
-  to use when creating orchestrator build
 - `can_orchestrate` (optional, boolean): allows using orchestrator build,
   default is false
 - `scratch_build_node_selector` (optional, str): a node selector to be applied
@@ -140,9 +138,8 @@ or worker builds.
 
 Based on `prod.json` there are `worker.json` and `orchestrator.json`.
 
-Based on `prod_inner.json` there are `orchestrator_inner:1.json` and
-`worker_inner:1.json`, where `1` is `arrangement_version` from configuration
-file, to specify default version.
+Based on `prod_inner.json` there are `orchestrator_inner:6.json` and
+`worker_inner:6.json`.
 
 Based on `prod_customize.json` there are `orchestrator_customize.json` and
 `worker_customize.json`.

--- a/make_mock_json.py
+++ b/make_mock_json.py
@@ -22,7 +22,7 @@ from textwrap import dedent
 from osbs import set_logging
 from osbs.api import OSBS
 from osbs.conf import Configuration
-from osbs.constants import DEFAULT_CONFIGURATION_FILE, DEFAULT_ARRANGEMENT_VERSION
+from osbs.constants import DEFAULT_CONFIGURATION_FILE
 from tests.constants import (TEST_BUILD, TEST_ORCHESTRATOR_BUILD, TEST_CANCELLED_BUILD)
 from osbs.exceptions import OsbsException
 from osbs.cli.capture import setup_json_capture
@@ -268,7 +268,6 @@ class MockCreator(object):
             'user': self.osbs.build_conf.get_user(),
             'release': TEST_BUILD,
             'platform': "x86_64",
-            'arrangement_version': DEFAULT_ARRANGEMENT_VERSION,
             'scratch': True,
         }
 
@@ -294,7 +293,6 @@ class MockCreator(object):
             'user': self.osbs.build_conf.get_user(),
             'release': TEST_BUILD,
             'platform': "x86_64",
-            'arrangement_version': DEFAULT_ARRANGEMENT_VERSION,
             'scratch': True,
         }
         build_id = ""

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -14,7 +14,7 @@ import json
 
 import six
 
-from osbs.constants import BUILD_TYPE_ORCHESTRATOR
+from osbs.constants import BUILD_TYPE_ORCHESTRATOR, DEFAULT_ARRANGEMENT_VERSION
 from osbs.exceptions import OsbsException
 
 logger = logging.getLogger(__name__)
@@ -357,7 +357,7 @@ class PluginsConfigurationBase(object):
         worker_params = [
             'component', 'git_branch', 'git_ref', 'git_uri', 'koji_task_id',
             'filesystem_koji_task_id', 'scratch', 'koji_target', 'user', 'yum_repourls',
-            'arrangement_version', 'koji_parent_build', 'isolated', 'reactor_config_map',
+            'koji_parent_build', 'isolated', 'reactor_config_map',
             'reactor_config_override', 'git_commit_depth',
         ]
 
@@ -496,10 +496,9 @@ class PluginsConfiguration(PluginsConfigurationBase):
 
     @property
     def pt_path(self):
-        arrangement_version = self.user_params.arrangement_version
         build_type = self.user_params.build_type
         #    <build_type>_inner:<arrangement_version>.json
-        return '{}_inner:{}.json'.format(build_type, arrangement_version)
+        return '{}_inner:{}.json'.format(build_type, DEFAULT_ARRANGEMENT_VERSION)
 
     def render(self):
         self.user_params.validate()
@@ -535,9 +534,8 @@ class SourceContainerPluginsConfiguration(PluginsConfigurationBase):
 
     @property
     def pt_path(self):
-        arrangement_version = self.user_params.arrangement_version
         # orchestrator_sources_inner:<arrangement_version>.json
-        return 'orchestrator_sources_inner:{}.json'.format(arrangement_version)
+        return 'orchestrator_sources_inner:{}.json'.format(DEFAULT_ARRANGEMENT_VERSION)
 
     def render(self):
         self.user_params.validate()

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -13,8 +13,7 @@ import random
 import json
 
 from osbs.build.user_params_meta import BuildParam, BuildParamsBase
-from osbs.constants import (DEFAULT_GIT_REF, REACTOR_CONFIG_ARRANGEMENT_VERSION,
-                            DEFAULT_CUSTOMIZE_CONF, RAND_DIGITS,
+from osbs.constants import (DEFAULT_GIT_REF, DEFAULT_CUSTOMIZE_CONF, RAND_DIGITS,
                             WORKER_MAX_RUNTIME, ORCHESTRATOR_MAX_RUNTIME,
                             USER_PARAMS_KIND_IMAGE_BUILDS,
                             USER_PARAMS_KIND_SOURCE_CONTAINER_BUILDS,
@@ -84,8 +83,6 @@ class BuildCommon(BuildParamsBase):
     # Must be defined in subclasses
     KIND = NotImplemented
 
-    arrangement_version = BuildParam("arrangement_version",
-                                     default=REACTOR_CONFIG_ARRANGEMENT_VERSION)
     # build_from contains the full build_from string, including the source type prefix
     build_from = BuildParam("build_from")
     # build_image contains the buildroot name, whether the buildroot is a straight image or an
@@ -136,7 +133,7 @@ class BuildCommon(BuildParamsBase):
         is created, however, overwriting defaults by setting None is allowed, e.g.:
 
         >>> params = BuildCommon.make_params(build_conf=bc)  # does not overwrite defaults
-        >>> params.arrangement_version = None  # does overwrite the default
+        >>> params.version = None  # does overwrite the default
 
         these parameters are accepted:
         :param base_image: str, name of the parent image
@@ -241,7 +238,7 @@ class BuildCommon(BuildParamsBase):
             timestamp
         ]
 
-        if self.platform and (self.arrangement_version or 0) >= 4:
+        if self.platform:
             tag_segments.append(self.platform)
 
         tag = '-'.join(tag_segments)

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -364,11 +364,6 @@ def cmd_build(args, osbs):
         'compose_ids': args.compose_ids,
         'operator_csv_modifications_url': args.operator_csv_modifications_url,
     }
-    if args.arrangement_version:
-        if args.arrangement_version < 6:
-            print("Arrangements less than 6 are no longer used.")
-            return -1
-        build_kwargs['arrangement_version'] = args.arrangement_version
 
     if args.koji_upload_dir:
         build_kwargs['koji_upload_dir'] = args.koji_upload_dir
@@ -391,11 +386,6 @@ def cmd_build_source_container(args, osbs):
         'sources_for_koji_build_id': args.sources_for_koji_build_id,
         'component': args.component,
     }
-    if args.arrangement_version:
-        if args.arrangement_version < 6:
-            print("Arrangements less than 6 are no longer used.")
-            return -1
-        build_kwargs['arrangement_version'] = args.arrangement_version
 
     build = osbs.create_source_container_build(**build_kwargs)
 
@@ -679,10 +669,6 @@ def cli():
                               help='release value to use')
     build_parser.add_argument('--isolated', action='store_true', required=False,
                               help='isolated build')
-    build_parser.add_argument('--arrangement-version', action='store', required=False,
-                              type=int,
-                              help='version of inner template to use; '
-                              'versions < 6 are unused')
     build_parser.add_argument('--signing-intent', action='store', required=False,
                               help='override signing intent of ODCS composes')
     build_parser.add_argument("--compose-id", action='append', required=False,
@@ -744,11 +730,6 @@ def cli():
     build_source_container_parser.add_argument(
         "--scratch", action='store_true', required=False,
         help="perform a scratch build"
-    )
-    build_source_container_parser.add_argument(
-        '--arrangement-version', action='store', required=False,
-        type=int,
-        help='version of inner template to use; versions < 6 are unused'
     )
     build_source_container_parser.add_argument(
         '--signing-intent', action='store', required=False,

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -18,9 +18,7 @@ from six.moves.urllib.parse import urljoin
 
 from osbs.constants import (DEFAULT_CONFIGURATION_FILE, DEFAULT_CONFIGURATION_SECTION,
                             GENERAL_CONFIGURATION_SECTION, DEFAULT_NAMESPACE,
-                            DEFAULT_ARRANGEMENT_VERSION, REACTOR_CONFIG_ARRANGEMENT_VERSION,
                             WORKER_MAX_RUNTIME, ORCHESTRATOR_MAX_RUNTIME)
-from osbs.exceptions import OsbsValidationException
 from osbs import utils
 
 
@@ -86,10 +84,9 @@ class Configuration(object):
             if value is not None:
                 # Only print deprecation warnings for cli or file arguments
                 if deprecated and func in (get_value_from_cli_args, get_value_from_conf):
-                    logger.warning("user configuration key '%s' in section '%s' is ignored in "
-                                   "arrangement %s and later. it has been deprecated in "
-                                   "favor of the value in the reactor_config_map",
-                                   args_key, conf_section, REACTOR_CONFIG_ARRANGEMENT_VERSION)
+                    logger.warning("user configuration key '%s' in section '%s' is ignored, "
+                                   "it has been deprecated in favor of the value in the"
+                                   " reactor_config_map", args_key, conf_section)
                 break
         else:  # we didn't break
             return default
@@ -319,15 +316,6 @@ class Configuration(object):
                              token_file, ex)
 
         return value
-
-    def get_arrangement_version(self):
-        value = self._get_value("arrangement_version", self.conf_section,
-                                "arrangement_version",
-                                default=DEFAULT_ARRANGEMENT_VERSION)
-        try:
-            return int(value)
-        except ValueError:
-            raise OsbsValidationException("Invalid arrangement_version: %s" % value)
 
     def get_can_orchestrate(self):
         return self._get_value("can_orchestrate", self.conf_section, "can_orchestrate",

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -23,7 +23,6 @@ WORKER_INNER_TEMPLATE = "worker_inner:{arrangement_version}.json"
 ORCHESTRATOR_INNER_TEMPLATE = "orchestrator_inner:{arrangement_version}.json"
 ORCHESTRATOR_SOURCES_INNER_TEMPLATE = "orchestrator_sources_inner:{arrangement_version}.json"
 DEFAULT_ARRANGEMENT_VERSION = 6  # this should be the highest-numbered version
-REACTOR_CONFIG_ARRANGEMENT_VERSION = 6
 WORKER_CUSTOMIZE_CONF = "worker_customize.json"
 ORCHESTRATOR_CUSTOMIZE_CONF = "orchestrator_customize.json"
 DEFAULT_OUTER_TEMPLATE = WORKER_OUTER_TEMPLATE

--- a/tests/build_/test_build_requestv2.py
+++ b/tests/build_/test_build_requestv2.py
@@ -765,12 +765,6 @@ class TestBuildRequestV2(object):
         ]},
          [],
          'Cannot set environment variable from reactor config (already exists): USER_PARAMS'),
-        # Conflicts with special environment variables
-        ({'build_env_vars': [
-            {'name': 'REACTOR_CONFIG', 'value': 'arrangement_version: 5'},
-        ]},
-         [],
-         'Cannot set environment variable from reactor config (already exists): REACTOR_CONFIG'),
         # Conflicts with itself
         ({'build_env_vars': [
             {'name': 'HTTP_PROXY', 'value': 'example.proxy.net'},

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -18,8 +18,7 @@ from osbs.build.plugins_configuration import (
     PluginsConfiguration,
     SourceContainerPluginsConfiguration,
 )
-from osbs.constants import (BUILD_TYPE_WORKER, BUILD_TYPE_ORCHESTRATOR,
-                            REACTOR_CONFIG_ARRANGEMENT_VERSION)
+from osbs.constants import (BUILD_TYPE_WORKER, BUILD_TYPE_ORCHESTRATOR)
 from osbs.exceptions import OsbsValidationException
 from osbs.conf import Configuration
 from osbs import utils
@@ -503,7 +502,6 @@ class TestPluginsConfiguration(object):
             platforms = {}
         assert plugin_value_get(plugins, phase, plugin, 'args', 'platforms') == platforms or {}
         build_kwargs = plugin_value_get(plugins, phase, plugin, 'args', 'build_kwargs')
-        assert build_kwargs['arrangement_version'] == REACTOR_CONFIG_ARRANGEMENT_VERSION
         assert build_kwargs.get('koji_parent_build') == koji_parent_build
         assert build_kwargs.get('reactor_config_map') == 'reactor-config-map'
         assert build_kwargs.get('reactor_config_override') == 'reactor-config-override'

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -24,8 +24,7 @@ from osbs.build.user_params import (
 from osbs.conf import Configuration
 from osbs.repo_utils import RepoInfo, RepoConfiguration
 from osbs.exceptions import OsbsValidationException
-from osbs.constants import (BUILD_TYPE_WORKER, REACTOR_CONFIG_ARRANGEMENT_VERSION,
-                            DEFAULT_CUSTOMIZE_CONF)
+from osbs.constants import (BUILD_TYPE_WORKER, DEFAULT_CUSTOMIZE_CONF)
 from tests.constants import (TEST_COMPONENT, TEST_FILESYSTEM_KOJI_TASK_ID,
                              TEST_GIT_BRANCH, TEST_GIT_REF, TEST_GIT_URI,
                              TEST_KOJI_TASK_ID, TEST_USER, INPUTS_PATH)
@@ -139,7 +138,6 @@ class TestBuildUserParams(object):
 
     def test_user_params_bad_json(self):
         required_json = json.dumps({
-            'arrangement_version': 6,
             'customize_conf': 'worker_customize.json',
             'git_ref': 'master',
             'kind': 'build_user_params',
@@ -227,7 +225,6 @@ class TestBuildUserParams(object):
 
         # all values that BuildUserParams stores
         param_kwargs = {
-            # 'arrangement_version': self.arrangement_version,  # calculated value
             'base_image': 'buildroot:old',
             # 'build_from': 'buildroot:old',  # only one of build_*
             'build_json_dir': INPUTS_PATH,
@@ -290,7 +287,6 @@ class TestBuildUserParams(object):
 
         spec = BuildUserParams.make_params(**param_kwargs)
         expected_json = {
-            "arrangement_version": REACTOR_CONFIG_ARRANGEMENT_VERSION,
             "base_image": "buildroot:old",
             "build_from": "image:buildroot:latest",
             "build_image": "buildroot:latest",
@@ -343,7 +339,6 @@ class TestBuildUserParams(object):
     def test_from_json_continue(self):
         spec = BuildUserParams()
         expected_json = {
-            "arrangement_version": REACTOR_CONFIG_ARRANGEMENT_VERSION,
             "base_image": "buildroot:old",
             "build_image": "buildroot:latest",
             "build_json_dir": "build_dir",
@@ -378,7 +373,6 @@ class TestBuildUserParams(object):
         kwargs = self.get_minimal_kwargs()
         params = BuildUserParams.make_params(**kwargs)
 
-        assert params.arrangement_version == REACTOR_CONFIG_ARRANGEMENT_VERSION
         assert params.buildroot_is_imagestream is False
         assert params.customize_conf == DEFAULT_CUSTOMIZE_CONF
         # assert params.git_ref == 'master'  # set from repo_info
@@ -445,7 +439,6 @@ class TestSourceContainerUserParams(object):
         spec = SourceContainerUserParams.make_params(**param_kwargs)
 
         expected_json = {
-            "arrangement_version": REACTOR_CONFIG_ARRANGEMENT_VERSION,
             "build_from": "image:buildroot:latest",
             "build_image": "buildroot:latest",
             "build_json_dir": INPUTS_PATH,

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -14,8 +14,6 @@ import argparse
 from copy import deepcopy
 from osbs.conf import Configuration
 from osbs import utils
-from osbs.exceptions import OsbsValidationException
-from osbs.constants import DEFAULT_ARRANGEMENT_VERSION
 import pytest
 from tempfile import NamedTemporaryFile
 import logging
@@ -243,22 +241,6 @@ class TestConfiguration(object):
 
             assert conf.get_builder_build_json_store() == expected
 
-    @pytest.mark.parametrize(('config', 'expected'), [
-        ({'default': {}}, DEFAULT_ARRANGEMENT_VERSION),
-
-        ({'default': {'arrangement_version': 50}}, 50),
-        ({'default': {'arrangement_version': 'one'}}, OsbsValidationException),
-    ])
-    def test_arrangement_version(self, config, expected):
-        with self.config_file(config) as config_file:
-            conf = Configuration(conf_file=config_file)
-
-        if isinstance(expected, type):
-            with pytest.raises(expected):
-                conf.get_arrangement_version()
-        else:
-            assert conf.get_arrangement_version() == expected
-
     @pytest.mark.parametrize(('platform', 'config', 'kwargs', 'expected'), [
         ('',
          {},
@@ -332,8 +314,6 @@ class TestConfiguration(object):
 
     def test_deprecated_warnings(self, caplog):  # noqa:F811
         with caplog.at_level(logging.WARNING):
-            self.test_arrangement_version({'default': {'deprecated_key': 'client_secret'}},
-                                          DEFAULT_ARRANGEMENT_VERSION)
             assert "it has been deprecated" not in caplog.text
             # kwargs don't get warnings
             self.test_param_retrieval(config={'default': {}},


### PR DESCRIPTION
Cleanup for tekton

* CLOUDBLD-6299

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
