### PR TITLE
Fix E741 ambiguous variable name 'l'

### DIFF
--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -699,7 +699,7 @@ class TestPluginsConfiguration(object):
         build_json = plugins_conf.render()
         plugins = get_plugins_from_build_json(build_json)
 
-        log_messages = [l.getMessage() for l in caplog.records]
+        log_messages = [log.getMessage() for log in caplog.records]
         assert 'Invalid custom configuration found for disable_plugins' in log_messages
         assert 'Invalid custom configuration found for enable_plugins' in log_messages
         assert plugin_value_get(plugins, 'prebuild_plugins', 'pull_base_image', 'args',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,7 +71,7 @@ class TestCheckResponse(object):
             else:
                 check_response(response, log_level=log_type)
 
-        logged = [(l.getMessage(), l.levelno) for l in caplog.records]
+        logged = [(log.getMessage(), log.levelno) for log in caplog.records]
         assert len(logged) == 1
         assert logged[0][0] == '[{code}] {message}'.format(code=status_code,
                                                            message=b'iterlines')
@@ -93,7 +93,7 @@ class TestCheckResponse(object):
             else:
                 check_response(response, log_level=log_type)
 
-        logged = [(l.getMessage(), l.levelno) for l in caplog.records]
+        logged = [(log.getMessage(), log.levelno) for log in caplog.records]
         assert len(logged) == 1
         assert logged[0][0] == '[{code}] {message}'.format(code=status_code,
                                                            message=content)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -555,7 +555,7 @@ def test_user_warnings_handler(message, expected, caplog):
         with caplog.at_level(USER_WARNING_LEVEL):
             logging.getLogger().user_warning(message)
 
-            logged = [(l.getMessage(), l.levelno) for l in caplog.records]
+            logged = [(log.getMessage(), log.levelno) for log in caplog.records]
             assert len(logged) == 1
             assert expected in logged[0][0]
             assert logged[0][1] == USER_WARNING_LEVEL


### PR DESCRIPTION
Context:
- https://github.com/containerbuildsystem/actions/pull/2

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
