### PR TITLE
Fix koji_task_id type in user_params docstring

### DIFF
--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -143,7 +143,7 @@ class BuildCommon(BuildParamsBase):
         :param component: str, name of the component
         :param koji_parent_build: str,
         :param koji_target: str, koji tag with packages used to build the image
-        :param koji_task_id: str, koji ID
+        :param koji_task_id: int, koji *task* ID
         :param koji_upload_dir: str, koji directory where the completed image will be uploaded
         :param platform: str, platform
         :param reactor_config_override: dict, data structure for reactor config to be injected as


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
