### PR TITLE
annotations repositories are string, also call correct method get_err…

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -141,7 +141,8 @@ def _display_pipeline_run_summary(pipeline_run):
     annotations = pipeline_run.get_info()['metadata']['annotations']
 
     if pipeline_run.has_succeeded():
-        all_repositories = annotations.get('repositories', {})
+        str_repositories = annotations.get('repositories', '{}')
+        all_repositories = json.loads(str_repositories)
 
         for kind, repositories in all_repositories.items():
             if not repositories:
@@ -150,7 +151,7 @@ def _display_pipeline_run_summary(pipeline_run):
             for repository in repositories:
                 output.append('\t{}'.format(repository))
     else:
-        output.append(pipeline_run.get_build_error_message())
+        output.append(pipeline_run.get_error_message())
 
     for line in output:
         print(line)


### PR DESCRIPTION
…or_message

* CLOUDBLD-7306

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
