### PR TITLE
pin down flexmock 0.11.0 and fix tests

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-flexmock>=0.10.3
+flexmock>=0.11.0
 pytest>=4.1.0
 pytest-cov
 pytest-html

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ of the BSD license. See the LICENSE file for details.
 """
 from __future__ import absolute_import
 
-from flexmock import flexmock, MethodCallError
+from flexmock import flexmock
 import pytest
 import json
 import copy
@@ -126,7 +126,7 @@ class TestOSBS(object):
             utils.get_repo_info(TEST_GIT_URI, TEST_GIT_REF)
 
         # Check we get the correct exception
-        with pytest.raises(MethodCallError):
+        with pytest.raises(OsbsException):
             dummy_api_function()
 
     def test_create_build_invalid_yaml(self, osbs_binary, tmpdir, monkeypatch):  # noqa


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
