### PR TITLE
check if the repo ws locally modified before resetting

### DIFF
--- a/osbs/exceptions.py
+++ b/osbs/exceptions.py
@@ -79,5 +79,9 @@ class OsbsValidationException(OsbsException):
     pass
 
 
+class OsbsLocallyModified(OsbsException):
+    """Local modifications found in repo"""
+
+
 class OsbsCommitNotFound(OsbsException):
     """Commit was not found in repo"""


### PR DESCRIPTION
In OSBS2 we'll reuse the same repo multiple times,
we need to make sure it's not modified locally
before resetting

* CLOUDBLD-7976

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
