### PR TITLE
[OCP3] add userdata cli option and pass userdata to koji_import plugin

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -511,6 +511,13 @@ class PluginsConfigurationBase(object):
             self.pt.set_plugin_arg_valid(phase, plugin, "dependency_replacements",
                                          self.user_params.dependency_replacements)
 
+    def render_koji_import(self, plugin):
+        phase = 'exit_plugins'
+
+        if self.pt.has_plugin_conf(phase, plugin):
+            self.pt.set_plugin_arg_valid(phase, plugin, "userdata",
+                                         self.user_params.userdata)
+
 
 class PluginsConfiguration(PluginsConfigurationBase):
     """Plugin configuration for image builds"""
@@ -550,6 +557,7 @@ class PluginsConfiguration(PluginsConfigurationBase):
         self.render_download_remote_source()
         self.render_resolve_remote_source()
         self.render_add_image_content_manifest()
+        self.render_koji_import('koji_import')
         return self.pt.to_json()
 
 
@@ -573,5 +581,6 @@ class SourceContainerPluginsConfiguration(PluginsConfigurationBase):
         self.render_koji()
         self.render_koji_tag_build()
         self.render_tag_and_push()
+        self.render_koji_import('koji_import_source_container')
 
         return self.pt.to_json()

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -104,6 +104,7 @@ class BuildCommon(BuildParamsBase):
     scratch = BuildParam("scratch")
     signing_intent = BuildParam("signing_intent")
     user = BuildParam("user", required=True)
+    userdata = BuildParam("userdata")
     worker_deadline = BuildParam("worker_deadline")
 
     def __setattr__(self, name, value):
@@ -123,6 +124,7 @@ class BuildCommon(BuildParamsBase):
                     scratch=None,
                     signing_intent=None,
                     user=None,
+                    userdata=None,
                     **kwargs):
         """
         Create a user_params instance.
@@ -155,6 +157,7 @@ class BuildCommon(BuildParamsBase):
         :param scratch: bool, build as a scratch build (if not specified in build_conf)
         :param signing_intent: bool, True to sign the resulting image
         :param user: str, name of the user requesting the build
+        :param userdata: dict, custom user data
 
         Please keep the paramater list alphabetized for easier tracking of changes
 
@@ -197,6 +200,7 @@ class BuildCommon(BuildParamsBase):
             "reactor_config_override": reactor_config_override,
             "signing_intent": signing_intent,
             "user": user,
+            "userdata": userdata,
             # Potentially pulled from build_conf
             "build_from": build_from,
             "build_image": source_value,

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -368,6 +368,9 @@ def cmd_build(args, osbs):
         'skip_build': args.skip_build,
         'operator_csv_modifications_url': args.operator_csv_modifications_url,
     }
+    if args.userdata:
+        build_kwargs['userdata'] = json.loads(args.userdata)
+
     if args.arrangement_version:
         if args.arrangement_version < 6:
             print("Arrangements less than 6 are no longer used.")
@@ -398,6 +401,8 @@ def cmd_build_source_container(args, osbs):
         'sources_for_koji_build_id': args.sources_for_koji_build_id,
         'component': args.component,
     }
+    if args.userdata:
+        build_kwargs['userdata'] = json.loads(args.userdata)
     if args.arrangement_version:
         if args.arrangement_version < 6:
             print("Arrangements less than 6 are no longer used.")
@@ -755,6 +760,8 @@ def cli():
     build_parser.add_argument("--operator-csv-modifications-url", action='store', required=False,
                               dest='operator_csv_modifications_url', metavar='URL',
                               help="URL to JSON file with operator CSV modification")
+    build_parser.add_argument("--userdata", required=False,
+                              help="JSON dictionary of user defined custom metadata")
 
     build_source_container_parser = subparsers.add_parser(
         str_on_2_unicode_on_3('build-source-container'),
@@ -813,6 +820,9 @@ def cli():
     build_source_container_parser.add_argument(
         '--signing-intent', action='store', required=False,
         help='override signing intent')
+    build_source_container_parser.add_argument(
+        '--userdata', required=False,
+        help='JSON dictionary of user defined custom metadata')
     build_source_container_parser.set_defaults(func=cmd_build_source_container)
 
     worker_group = build_parser.add_argument_group(title='arguments for --worker',

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -931,6 +931,25 @@ class TestPluginsConfiguration(object):
             plugin_args = plugin_value_get(plugins, phase, plugin, 'args')
             assert plugin_args.get('remote_sources') == remote_sources
 
+    @pytest.mark.parametrize('userdata', (None, {}, {'custom': 'userdata'}))
+    def test_userdata(self, userdata):
+        phase = 'exit_plugins'
+        plugin = 'koji_import'
+        extra_args = {
+            'userdata': userdata,
+        }
+        user_params = get_sample_user_params(extra_args=extra_args)
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+        assert get_plugin(plugins, phase, plugin)
+
+        if userdata is None:
+            assert 'args' not in plugin
+        else:
+            assert plugin_value_get(plugins, phase, plugin, 'args')
+            args = plugin_value_get(plugins, phase, plugin, 'args')
+            assert args['userdata'] == userdata
+
 
 class TestSourceContainerPluginsConfiguration(object):
 
@@ -979,3 +998,24 @@ class TestSourceContainerPluginsConfiguration(object):
             assert args['koji_build_id'] == expected_build_id
         if signing_intent:
             assert args['signing_intent'] == expected_intent
+
+    @pytest.mark.parametrize('userdata', (None, {}, {'custom': 'userdata'}))
+    def test_userdata(self, userdata):
+        plugin_type = 'exit_plugins'
+        plugin_name = 'koji_import_source_container'
+        additional_params = {
+            'userdata': userdata,
+        }
+
+        user_params = source_container_user_params(extra_args=additional_params)
+        build_json = SourceContainerPluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+        assert get_plugin(plugins, plugin_type, plugin_name)
+        plugin = get_plugin(plugins, plugin_type, plugin_name)
+
+        if userdata is None:
+            assert 'args' not in plugin
+        else:
+            assert plugin_value_get(plugins, plugin_type, plugin_name, 'args')
+            args = plugin_value_get(plugins, plugin_type, plugin_name, 'args')
+            assert args['userdata'] == userdata

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -224,6 +224,7 @@ class TestBuildUserParams(object):
         repo_info = RepoInfo(configuration=repo_conf)
         build_conf = Configuration(conf_file=None, build_from='image:buildroot:latest',
                                    orchestrator_deadline=4, scratch=False, worker_deadline=3)
+        userdata = {'custom': 'userdata'}
 
         # all values that BuildUserParams stores
         param_kwargs = {
@@ -269,6 +270,7 @@ class TestBuildUserParams(object):
             'task_id': TEST_KOJI_TASK_ID,
             # 'trigger_imagestreamtag': 'base_image:latest',  # generated from base_image
             'user': TEST_USER,
+            'userdata': userdata,
             # 'yum_repourls': ,  # not used with compose_ids
             # "worker_deadline": 3,  # set in config
         }
@@ -328,6 +330,7 @@ class TestBuildUserParams(object):
             "release": "29",
             "trigger_imagestreamtag": "buildroot:old",
             "user": TEST_USER,
+            "userdata": userdata,
             "worker_deadline": 3,
         }
         assert spec.to_json() == json.dumps(expected_json, sort_keys=True)
@@ -423,6 +426,7 @@ class TestSourceContainerUserParams(object):
             'scratch': True,
             'worker_max_run_hours': 3,
         }
+        userdata = {'custom': 'userdata'}
         param_kwargs = self.get_minimal_kwargs(origin_nvr, conf_args=conf_args)
         param_kwargs.update({
             'component': TEST_COMPONENT,
@@ -430,6 +434,7 @@ class TestSourceContainerUserParams(object):
             "platform": "x86_64",
             "signing_intent": "test-signing-intent",
             "sources_for_koji_build_id": origin_id,
+            "userdata": userdata,
         })
 
         rand = '12345'
@@ -462,6 +467,7 @@ class TestSourceContainerUserParams(object):
             'reactor_config_map': 'reactor-config-map-scratch',
             'scratch': True,
             "user": TEST_USER,
+            "userdata": userdata,
             "worker_deadline": 3,
         }
         if origin_id:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2449,6 +2449,7 @@ class TestOSBS(object):
                 self.compose_ids = [1, 2]
                 self.skip_build = False
                 self.operator_csv_modifications_url = None
+                self.userdata = None
 
         expected_kwargs = {
             'platform': platform,
@@ -2535,6 +2536,7 @@ class TestOSBS(object):
                 self.compose_ids = None
                 self.skip_build = skip_build
                 self.operator_csv_modifications_url = None
+                self.userdata = None
 
         expected_kwargs = {
             'platform': None,
@@ -2605,6 +2607,7 @@ class TestOSBS(object):
                 self.compose_ids = [1, 2]
                 self.skip_build = False
                 self.operator_csv_modifications_url = None
+                self.userdata = None
 
         expected_kwargs = {
             'platform': None,
@@ -2688,6 +2691,7 @@ class TestOSBS(object):
                 self.compose_ids = None
                 self.skip_build = False
                 self.operator_csv_modifications_url = "https://example.com/updates.json"
+                self.userdata = None
 
         expected_kwargs = {
             'platform': None,


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
