### PR TITLE
CLI: Remove --output option

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -324,8 +324,6 @@ def cli():
                         help="get and supply oauth token with every request")
     parser.add_argument("--without-auth", action="store_false", dest="use_auth", default=None,
                         help="don't supply oauth tokens to requests")
-    parser.add_argument("--output", choices=["json", "text"], default="text",
-                        help="pick output type (default=text)")
     parser.add_argument("--namespace", help="name of namespace to query against",
                         metavar="NAMESPACE", action="store")
     parser.add_argument("--capture-dir", metavar="DIR", action="store",


### PR DESCRIPTION
This option is unused

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
