### PR TITLE
pipeline run error message about plugins should be same as before

### DIFF
--- a/osbs/tekton.py
+++ b/osbs/tekton.py
@@ -501,9 +501,8 @@ class PipelineRun():
         err_message = ""
 
         if plugin_errors:
-            err_message = "plugin errors:\n"
             for plugin, error in plugin_errors.items():
-                err_message += f"{plugin} : {error}\n"
+                err_message += f"Error in plugin {plugin}: {error}\n"
 
         err_message += "\npipeline run errors:\n"
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1071,7 +1071,7 @@ class TestOSBS(object):
 
         flexmock(PipelineRun).should_receive('get_info').and_return(resp)
 
-        error_msg = "plugin errors:\nplugin1 : error1\n\npipeline run errors:\n"
+        error_msg = "Error in plugin plugin1: error1\n\npipeline run errors:\n"
         error_msg += "pipeline task 'task2' failed:\n"
         error_msg += "task step 'step2' failed with exit code: 128 and reason: 'bad thing'"
 

--- a/tests/test_tekton.py
+++ b/tests/test_tekton.py
@@ -465,8 +465,9 @@ class TestPipelineRun():
         ({'status': {'conditions': [{'reason': 'reason1', 'message': 'message1'}]},
           'metadata': {'annotations': {'plugins-metadata': '{"errors": {"plugin1": "error1",'
                                                            '"plugin2": "error2"}}'}}},
-         "plugin errors:\nplugin1 : error1\nplugin2 : error2\n\npipeline run errors:\npipeline "
-         "run source-container-x-x-default failed with reason: 'reason1' and message: 'message1'"),
+         "Error in plugin plugin1: error1\nError in plugin plugin2: error2\n\npipeline run errors:"
+         "\npipeline run source-container-x-x-default failed with reason: 'reason1' and message: "
+         "'message1'"),
 
         # taskRuns in status, without steps
         ({'status': {'conditions': [{'reason': 'reason1', 'message': 'message1'}],
@@ -474,8 +475,8 @@ class TestPipelineRun():
                                                                        'message': 'message2'}]}}}},
           'metadata': {'annotations': {'plugins-metadata': '{"errors": {"plugin1": "error1",'
                                                            '"plugin2": "error2"}}'}}},
-         "plugin errors:\nplugin1 : error1\nplugin2 : error2\n\npipeline run errors:\n"
-         "pipeline task 'task1' failed:\ntask run 'task1' failed with reason: 'reason2' "
+         "Error in plugin plugin1: error1\nError in plugin plugin2: error2\n\npipeline run errors:"
+         "\npipeline task 'task1' failed:\ntask run 'task1' failed with reason: 'reason2' "
          "and message: 'message2'"),
 
         # taskRuns in status, with steps
@@ -491,8 +492,8 @@ class TestPipelineRun():
                                                                   'reason': 'step_reason'}}]}}}},
           'metadata': {'annotations': {'plugins-metadata': '{"errors": {"plugin1": "error1",'
                                                            '"plugin2": "error2"}}'}}},
-         "plugin errors:\nplugin1 : error1\nplugin2 : error2\n\npipeline run errors:\n"
-         "pipeline task 'task1' failed:\ntask step 'step_ko' failed with exit code: 1 "
+         "Error in plugin plugin1: error1\nError in plugin plugin2: error2\n\npipeline run errors:"
+         "\npipeline task 'task1' failed:\ntask step 'step_ko' failed with exit code: 1 "
          "and reason: 'step_reason'"),
     ])  # noqa
     def test_get_error_message(self, pipeline_run, get_json, error_lines):


### PR DESCRIPTION
* CLOUDBLD-8281

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
