### PR TITLE
wait_for_finish method, which waits for pipeline run to finish, after we

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -441,6 +441,11 @@ class OSBS(object):
         return pipeline_run.has_not_finished()
 
     @osbsapi
+    def wait_for_build_to_finish(self, build_name):
+        pipeline_run = PipelineRun(self.os, build_name)
+        return pipeline_run.wait_for_finish()
+
+    @osbsapi
     def build_was_cancelled(self, build_name):
         pipeline_run = PipelineRun(self.os, build_name)
         return pipeline_run.was_cancelled()

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -89,6 +89,7 @@ def _get_build_metadata(pipeline_run, user_warnings_store):
 def print_output(pipeline_run, export_metadata_file=None):
     user_warnings_store = UserWarningsStore()
     get_logs_passed = _print_pipeline_run_logs(pipeline_run, user_warnings_store)
+    pipeline_run.wait_for_finish()
     build_metadata = _get_build_metadata(pipeline_run, user_warnings_store)
     _display_pipeline_run_summary(build_metadata)
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -7,6 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 import json
 import os
+import time
 from textwrap import dedent
 
 from flexmock import flexmock
@@ -23,6 +24,7 @@ def test_print_output(tmpdir, capsys):
       * if STDOUT is correct
       * if JSON exported metadata are correct
     """
+    flexmock(time).should_receive('sleep').and_return(None)
     ppln_run = flexmock(PipelineRun(flexmock(), 'test_ppln'))
     (ppln_run
      .should_receive('get_info')
@@ -42,6 +44,7 @@ def test_print_output(tmpdir, capsys):
      ))
     ppln_run.should_receive('has_succeeded').and_return(True)
     ppln_run.should_receive('status_reason').and_return('complete')
+    ppln_run.should_receive('has_not_finished').and_return(False)
     (ppln_run
      .should_receive('get_logs')
      .and_return([
@@ -102,6 +105,7 @@ def test_print_output_failure(tmpdir, capsys, get_logs_failed, build_not_finishe
       * if STDOUT is correct when build failed
       * if JSON exported metadata are correct
     """
+    flexmock(time).should_receive('sleep').and_return(None)
     ppln_run = flexmock(PipelineRun(flexmock(), 'test_ppln'))
     ppln_run.should_receive('has_succeeded').and_return(False)
     ppln_run.should_receive('status_reason').and_return('failed')


### PR DESCRIPTION
finished reading logs, there is race between all pods finished and
pipeline run changing status

we will wait just for certain amount of time, if pipeline run still
didn't finish by then, there is something really wrong and that will be
already handled

* CLOUDBLD-8359

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a] JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
