### PR TITLE
Revert "add more debugging for update_labels, so we can find out why …

### DIFF
--- a/osbs/tekton.py
+++ b/osbs/tekton.py
@@ -445,10 +445,7 @@ class PipelineRun():
         data = copy.deepcopy(self.minimal_data)
 
         sanitized_labels = {k: sanitize_strings_for_openshift(v) for k, v in labels.items()}
-        logger.debug("update labels called with: %s", labels)
         data['metadata']['labels'] = sanitized_labels
-        logger.debug("sanitized labels: %s", sanitized_labels)
-        logger.debug("labels before update: %s", self.labels)
 
         response = self.os.patch(
             self.pipeline_run_url,
@@ -463,8 +460,6 @@ class PipelineRun():
         exc_msg = f"Can't update labels on pipeline run '{self.pipeline_run_name}', " \
                   f"because it doesn't exist"
         response_json = self._check_response(response, msg)
-        logger.debug("labels after update: %s", self.labels)
-        logger.debug("response_json: %s", response_json)
         if not response_json:
             raise OsbsException(exc_msg)
         return response_json

--- a/tests/test_tekton.py
+++ b/tests/test_tekton.py
@@ -377,7 +377,6 @@ class TestPipelineRun():
         expect_labels = {'label_key': 'labelvalue'}
         exp_request_body_pipeline_run = deepcopy(PIPELINE_MINIMAL_DATA)
         exp_request_body_pipeline_run['metadata']['labels'] = expect_labels
-        labels_json = {'metadata': {'labels': {'label': 'key'}}}
 
         responses.add(
             responses.PATCH,
@@ -386,10 +385,6 @@ class TestPipelineRun():
             json=get_json,
             status=status,
         )
-        # this is just for debugging messages which report labels before and after update
-        responses.add(responses.GET, PIPELINE_RUN_URL, json=labels_json)
-
-        response_calls = 3
 
         if raises:
             exc_msg = None
@@ -398,7 +393,6 @@ class TestPipelineRun():
                 exc_msg = f"Can't update labels on pipeline run " \
                           f"'{PIPELINE_RUN_NAME}', because it doesn't exist"
             elif status != 200:
-                response_calls = 2
                 log_msg = f"update labels on pipeline run '{PIPELINE_RUN_NAME}' " \
                           f"failed with : [{status}] {get_json}"
 
@@ -412,7 +406,7 @@ class TestPipelineRun():
         else:
             pipeline_run.update_labels(labels)
 
-        assert len(responses.calls) == response_calls
+        assert len(responses.calls) == 1
 
     @responses.activate
     @pytest.mark.parametrize(('get_json', 'status', 'raises'), [


### PR DESCRIPTION
…labels"

This reverts commit 3a67d8a1b5e961cd35cbf9293ee98ea2bbd4ebb7.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
