### PR TITLE
Add methods for fetching Tekton results

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -8,12 +8,14 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import print_function, unicode_literals, absolute_import
 
 from collections import namedtuple
+import json
 import logging
 import sys
 import warnings
 import yaml
 from functools import wraps
 from contextlib import contextmanager
+from typing import Any, Dict, Tuple
 
 from osbs.build.user_params import (
     BuildUserParams,
@@ -484,6 +486,29 @@ class OSBS(object):
     def get_build_error_message(self, build_name):
         pipeline_run = PipelineRun(self.os, build_name)
         return pipeline_run.get_error_message()
+
+    @osbsapi
+    def get_build_results(self, build_name) -> Dict[str, Any]:
+        """Fetch the pipelineResults for this build.
+
+        Converts the results array to a dict of {name: <JSON-decoded value>} and filters out
+        results with null values.
+        """
+        pipeline_run = PipelineRun(self.os, build_name)
+        pipeline_results = pipeline_run.pipeline_results
+
+        def load_result(result: Dict[str, str]) -> Tuple[str, Any]:
+            name = result['name']
+            raw_value = result['value']
+            try:
+                value = json.loads(raw_value)
+            except json.JSONDecodeError:
+                raise OsbsValidationException(f'{name} value is not valid JSON: {raw_value!r}')
+            return name, value
+
+        return {
+            name: value for name, value in map(load_result, pipeline_results) if value is not None
+        }
 
     @contextmanager
     def retries_disabled(self):

--- a/osbs/tekton.py
+++ b/osbs/tekton.py
@@ -11,6 +11,7 @@ import base64
 import os
 import requests
 import copy
+from typing import Dict, List
 
 
 from osbs.exceptions import OsbsResponseException, OsbsAuthException, OsbsException
@@ -604,6 +605,14 @@ class PipelineRun():
         if not data:
             return None
         return data['status']['conditions'][0]['status']
+
+    @property
+    def pipeline_results(self) -> List[Dict[str, str]]:
+        data = self.data
+        if not data:
+            return []
+
+        return data['status'].get('pipelineResults', [])
 
     def wait_for_start(self):
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1076,3 +1076,24 @@ class TestOSBS(object):
         error_msg += "task step 'step2' failed with exit code: 128 and reason: 'bad thing'"
 
         assert error_msg == osbs_binary.get_build_error_message('run_name')
+
+    def test_get_build_results(self, osbs_binary):
+        pipeline_results = [
+            {'name': 'number', 'value': '42'},
+            {'name': 'string', 'value': '"spam"'},
+            {'name': 'filter_me_out', 'value': 'null'},
+        ]
+        flexmock(PipelineRun).should_receive('pipeline_results').and_return(pipeline_results)
+
+        assert osbs_binary.get_build_results('run_name') == {'number': 42, 'string': 'spam'}
+
+    def test_get_build_results_invalid_json(self, osbs_binary):
+        pipeline_results = [
+            {'name': 'invalid_string', 'value': 'spam'},
+        ]
+        flexmock(PipelineRun).should_receive('pipeline_results').and_return(pipeline_results)
+
+        err_msg = "invalid_string value is not valid JSON: 'spam'"
+
+        with pytest.raises(OsbsValidationException, match=err_msg):
+            osbs_binary.get_build_results('run_name')

--- a/tests/test_tekton.py
+++ b/tests/test_tekton.py
@@ -530,6 +530,32 @@ class TestPipelineRun():
         assert pipeline_run.status_reason == reason
 
     @responses.activate
+    @pytest.mark.parametrize(
+        'get_json, expect_results',
+        [
+            ({}, []),
+            ({'status': {}}, []),
+            (
+                {"status": {"pipelineResults": [{'name': 'foo', 'value': '1234'}]}},
+                [{'name': 'foo', 'value': '1234'}],
+            ),
+            (
+                {
+                    "status": {
+                        "pipelineResults": [
+                            {'name': 'x', 'value': '1'}, {'name': 'y', 'value': '2'},
+                        ],
+                    },
+                },
+                [{'name': 'x', 'value': '1'}, {'name': 'y', 'value': '2'}],
+            ),
+        ],
+    )
+    def test_pipeline_results(self, pipeline_run, get_json, expect_results):
+        responses.add(responses.GET, PIPELINE_RUN_URL, json=get_json)
+        assert pipeline_run.pipeline_results == expect_results
+
+    @responses.activate
     @pytest.mark.parametrize(('status', 'reason', 'sleep_times'), [
         ('True', 'Succeeded', 0),
         ('False', 'Failed', 0),


### PR DESCRIPTION
CLOUDBLD-8889

Add the PipelineRun.pipeline_results property to fetch the raw value of
the .status.pipelineResults field.

Add the OSBS.get_build_results() method to fetch pipeline results and
convert them into a dict with JSON-decoded values.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
