### PR TITLE
return logs with the task name that they belong to

### DIFF
--- a/osbs/tekton.py
+++ b/osbs/tekton.py
@@ -675,8 +675,9 @@ class PipelineRun():
     def _get_logs_stream(self):
         self.wait_for_start()
         for task_run in self.wait_for_taskruns():
-            yield from TaskRun(os=self.os, task_run_name=task_run).get_logs(
-                follow=True, wait=True)
+            for log_line in TaskRun(os=self.os, task_run_name=task_run).get_logs(follow=True,
+                                                                                 wait=True):
+                yield task_run, log_line
 
     def get_logs(self, follow=False, wait=False):
         if wait or follow:

--- a/tests/test_tekton.py
+++ b/tests/test_tekton.py
@@ -625,4 +625,4 @@ class TestPipelineRun():
         logs = [line for line in pipeline_run.get_logs(follow=True, wait=True)]
 
         assert len(responses.calls) == 11
-        assert logs == ['Hello World', 'Bye World']
+        assert logs == [('test-task-run-1', 'Hello World'), ('test-task-run-1', 'Bye World')]


### PR DESCRIPTION
This is to later help separate log by platfrom that is
suffixed in the taskname

* CLOUDBLD-8139

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
