### PR TITLE
Fix printing of logs in cli.main

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -46,7 +46,7 @@ def _print_pipeline_run_logs(pipeline_run, user_warnings_store):
         return False
     print(f"Pipeline run created ({pipeline_run_name}), watching logs (feel free to interrupt)")
     try:
-        for line in pipeline_run_logs:
+        for _, line in pipeline_run_logs:
             if user_warnings_store.is_user_warning(line):
                 user_warnings_store.store(line)
                 continue

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -45,13 +45,19 @@ def test_print_output(tmpdir, capsys):
     ppln_run.should_receive('has_succeeded').and_return(True)
     ppln_run.should_receive('status_reason').and_return('complete')
     ppln_run.should_receive('has_not_finished').and_return(False)
-    (ppln_run
-     .should_receive('get_logs')
-     .and_return([
+
+    log_entries = [
         '2021-11-25 23:17:49,886 platform:- - atomic_reactor.inner - INFO - YOLO 1',
         '2021-11-25 23:17:50,000 platform:- - smth - USER_WARNING - {"message": "user warning"}',
         '2021-11-25 23:17:59,123 platform:- - atomic_reactor.inner - INFO - YOLO 2',
-     ]))
+     ]
+
+    def get_logs():
+        task_run_name = "some-task-run"
+        for log in log_entries:
+            yield task_run_name, log
+
+    ppln_run.should_receive('get_logs').and_return(get_logs())
 
     export_metadata_file = os.path.join(tmpdir, 'metadata.json')
     print_output(ppln_run, export_metadata_file=export_metadata_file)
@@ -118,8 +124,9 @@ def test_print_output_failure(tmpdir, capsys, get_logs_failed, build_not_finishe
      ]
 
     def get_logs():
+        task_run_name = "some-task-run"
         for log in log_entries:
-            yield log
+            yield task_run_name, log
         if get_logs_failed:
             raise Exception("error reading logs")
 


### PR DESCRIPTION
The get_logs(follow=True, wait=True) method was updated to return an
iterator of (task_run_name, log_line) tuples. Fix its usage in the cli
and the mocking in unit tests accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
