### PR TITLE
don't pass `pipeline_run_name` in `user_params`

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015-2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -312,8 +312,6 @@ class OSBS(object):
 
         pipeline_run_name, pipeline_run_data = self._get_binary_container_pipeline_data(user_params)
 
-        user_params.pipeline_run_name = pipeline_run_name
-
         self._set_binary_container_pipeline_data(pipeline_run_name, pipeline_run_data, user_params)
 
         logger.info("creating binary container image pipeline run: %s", pipeline_run_name)
@@ -398,7 +396,6 @@ class OSBS(object):
             component=component,
             koji_target=target,
             koji_task_id=koji_task_id,
-            pipeline_run_name=pipeline_run_name,
             **kwargs
         )
 

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -85,7 +85,6 @@ class BuildCommon(BuildParamsBase):
     image_tag = BuildParam("image_tag")
     koji_target = BuildParam("koji_target")
     koji_task_id = BuildParam("koji_task_id")
-    pipeline_run_name = BuildParam("pipeline_run_name")
     platform = BuildParam("platform")
     reactor_config_map = BuildParam("reactor_config_map")
     scratch = BuildParam("scratch")
@@ -103,7 +102,6 @@ class BuildCommon(BuildParamsBase):
                     component=None,
                     koji_target=None,
                     koji_task_id=None,
-                    pipeline_run_name=None,
                     platform=None,
                     scratch=None,
                     signing_intent=None,
@@ -132,7 +130,6 @@ class BuildCommon(BuildParamsBase):
         :param koji_target: str, koji tag with packages used to build the image
         :param koji_task_id: int, koji *task* ID
         :param koji_upload_dir: str, koji directory where the completed image will be uploaded
-        :param pipeline_run_name: str, name of the pipeline run
         :param platform: str, platform
         :param scratch: bool, build as a scratch build (if not specified in build_conf)
         :param signing_intent: bool, True to sign the resulting image
@@ -162,7 +159,6 @@ class BuildCommon(BuildParamsBase):
             "user": user,
             "userdata": userdata,
             # Potentially pulled from build_conf
-            "pipeline_run_name": pipeline_run_name,
             "reactor_config_map": reactor_config,
             "scratch": build_conf.get_scratch(scratch),
         })

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -760,7 +760,6 @@ class TestOSBS(object):
                 if koji_task_id:
                     expect_up['koji_task_id'] = koji_task_id
                 expect_up['name'] = name
-                expect_up['pipeline_run_name'] = pipeline_run_name
                 expect_up['koji_target'] = TEST_TARGET
                 expect_up['user'] = TEST_USER
                 expect_up['signing_intent'] = signing_intent
@@ -891,7 +890,6 @@ class TestOSBS(object):
                 expect_up['kind'] = SourceContainerUserParams.KIND
                 if koji_task_id:
                     expect_up['koji_task_id'] = koji_task_id
-                expect_up['pipeline_run_name'] = pipeline_run_name
                 expect_up['koji_target'] = TEST_TARGET
                 expect_up['user'] = TEST_USER
                 expect_up['image_tag'] = image_tag


### PR DESCRIPTION
It can be fetched from context in tekton
so no need to pass it.

* CLOUDBLD-9053

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
