### PR TITLE
don't pass `namespace` in `user_params`

### DIFF
--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2018 Red Hat, Inc
+Copyright (c) 2018-2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -85,7 +85,6 @@ class BuildCommon(BuildParamsBase):
     image_tag = BuildParam("image_tag")
     koji_target = BuildParam("koji_target")
     koji_task_id = BuildParam("koji_task_id")
-    namespace = BuildParam("namespace")
     pipeline_run_name = BuildParam("pipeline_run_name")
     platform = BuildParam("platform")
     reactor_config_map = BuildParam("reactor_config_map")
@@ -143,7 +142,6 @@ class BuildCommon(BuildParamsBase):
         Please keep the paramater list alphabetized for easier tracking of changes
 
         the following parameters are pulled from the BuildConfiguration (ie, build_conf)
-        :param namespace: str, openshift namespace
         :param reactor_config_map: str, name of the config map containing the reactor environment
         :param scratch: bool, build as a scratch build
         """
@@ -159,7 +157,6 @@ class BuildCommon(BuildParamsBase):
             "component": component,
             "koji_target": koji_target,
             "koji_task_id": koji_task_id,
-            "namespace": build_conf.get_namespace(),
             "platform": platform,
             "signing_intent": signing_intent,
             "user": user,

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015-2018 Red Hat, Inc
+Copyright (c) 2015-2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -22,12 +22,11 @@ from osbs.build.user_params import (
     load_user_params_from_json,
 )
 from osbs.conf import Configuration
-from osbs.constants import DEFAULT_NAMESPACE
 from osbs.repo_utils import RepoInfo, RepoConfiguration
 from osbs.exceptions import OsbsValidationException
 from tests.constants import (TEST_COMPONENT, TEST_FILESYSTEM_KOJI_TASK_ID,
                              TEST_GIT_BRANCH, TEST_GIT_REF, TEST_GIT_URI,
-                             TEST_KOJI_TASK_ID, TEST_USER, TEST_OCP_NAMESPACE)
+                             TEST_KOJI_TASK_ID, TEST_USER)
 import osbs.utils
 
 
@@ -278,7 +277,6 @@ class TestBuildUserParams(object):
             "koji_parent_build": "fedora-26-9",
             "koji_target": "tothepoint",
             "name": "path-master-cd1e4" + f'{rand}-{timestr}',
-            "namespace": DEFAULT_NAMESPACE,
             'operator_bundle_replacement_pullspecs': {
                 'foo/fedora:30': 'bar/fedora@sha256:deadbeef'
             },
@@ -323,7 +321,6 @@ class TestBuildUserParams(object):
             "koji_parent_build": "fedora-26-9",
             "koji_target": "tothepoint",
             "name": "path-master-cd1e4",
-            "namespace": TEST_OCP_NAMESPACE,
             "orchestrator_deadline": 4,
             "platform": "x86_64",
             "platforms": ["x86_64"],
@@ -376,7 +373,6 @@ class TestSourceContainerUserParams(object):
     ])
     def test_all_values_and_json(self, scratch, origin_nvr, origin_id):
         conf_args = {
-            'namespace': TEST_OCP_NAMESPACE,
             'reactor_config_map_scratch': 'reactor-config-map-scratch',
             'reactor_config_map': 'reactor-config-map',
             'scratch': scratch,
@@ -413,7 +409,6 @@ class TestSourceContainerUserParams(object):
             "signing_intent": "test-signing-intent",
             "sources_for_koji_build_nvr": origin_nvr,
             "koji_target": "tothepoint",
-            "namespace": TEST_OCP_NAMESPACE,
             "platform": "x86_64",
             'reactor_config_map': 'reactor-config-map',
             "user": TEST_USER,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015-2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -760,7 +760,6 @@ class TestOSBS(object):
                 if koji_task_id:
                     expect_up['koji_task_id'] = koji_task_id
                 expect_up['name'] = name
-                expect_up['namespace'] = TEST_OCP_NAMESPACE
                 expect_up['pipeline_run_name'] = pipeline_run_name
                 expect_up['koji_target'] = TEST_TARGET
                 expect_up['user'] = TEST_USER
@@ -892,7 +891,6 @@ class TestOSBS(object):
                 expect_up['kind'] = SourceContainerUserParams.KIND
                 if koji_task_id:
                     expect_up['koji_task_id'] = koji_task_id
-                expect_up['namespace'] = TEST_OCP_NAMESPACE
                 expect_up['pipeline_run_name'] = pipeline_run_name
                 expect_up['koji_target'] = TEST_TARGET
                 expect_up['user'] = TEST_USER


### PR DESCRIPTION
`namespace` can be retrieved from pipeline
context in tekton.

* CLOUDBLD-9054

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
