### PR TITLE
Drop build-host label

### DIFF
--- a/osbs/utils/labels.py
+++ b/osbs/utils/labels.py
@@ -26,7 +26,6 @@ class Labels(object):
     - LABEL_TYPE_VENDOR: owner of the image
     - LABEL_TYPE_SOURCE: authoritative location for publishing
     - LABEL_TYPE_COMPONENT: Bugzilla (or other tracker) component
-    - LABEL_TYPE_HOST: build host used to create the image
     - LABEL_TYPE_RUN: command to run the image
     - LABEL_TYPE_INSTALL: command to install the image
     - LABEL_TYPE_UNINSTALL: command to uninstall the image
@@ -40,7 +39,6 @@ class Labels(object):
     LABEL_TYPE_VENDOR = object()
     LABEL_TYPE_SOURCE = object()
     LABEL_TYPE_COMPONENT = object()
-    LABEL_TYPE_HOST = object()
     LABEL_TYPE_RUN = object()
     LABEL_TYPE_INSTALL = object()
     LABEL_TYPE_UNINSTALL = object()
@@ -54,7 +52,6 @@ class Labels(object):
         LABEL_TYPE_VENDOR: ('vendor', 'Vendor'),
         LABEL_TYPE_SOURCE: ('authoritative-source-url', 'Authoritative_Registry'),
         LABEL_TYPE_COMPONENT: ('com.redhat.component', 'BZComponent'),
-        LABEL_TYPE_HOST: ('com.redhat.build-host', 'Build_Host'),
         LABEL_TYPE_RUN: ('run', 'RUN'),
         LABEL_TYPE_INSTALL: ('install', 'INSTALL'),
         LABEL_TYPE_UNINSTALL: ('uninstall', 'UNINSTALL'),

--- a/tests/utils/test_labels.py
+++ b/tests/utils/test_labels.py
@@ -32,7 +32,7 @@ from osbs.utils.labels import Labels
      TypeError),  # arg is required
     ({},
      ("get_new_names_by_old", None),
-     {"Vendor": "vendor", "Name": "name", "Build_Host": "com.redhat.build-host",
+     {"Vendor": "vendor", "Name": "name",
       "Version": "version", "Architecture": "architecture",
       "Release": "release", "BZComponent": "com.redhat.component",
       "Authoritative_Registry": "authoritative-source-url",


### PR DESCRIPTION
CLOUDBLD-8832

OSBS will not provide this label anymore.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
