### PR TITLE
Replacing logger.debug with logger.error

### DIFF
--- a/osbs/utils/yaml.py
+++ b/osbs/utils/yaml.py
@@ -84,11 +84,11 @@ def validate_with_schema(data, schema):
         logger.error('invalid schema, cannot validate')
         raise
     except jsonschema.ValidationError as exc:
-        logger.debug("schema validation error: %s", exc)
+        logger.error("schema validation error: %s", exc)
         exc_message = get_error_message(exc)
         for error in validator.iter_errors(data):
             error_message = get_error_message(error)
-            logger.debug("validation error: %s", error_message)
+            logger.error("validation error: %s", error_message)
         raise OsbsValidationException(exc_message)
 
 


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
