### PR TITLE
Add methods to check failed/cancelled taskRuns

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -418,6 +418,16 @@ class OSBS(object):
         return pipeline_run.was_cancelled()
 
     @osbsapi
+    def build_has_any_failed_tasks(self, build_name):
+        pipeline_run = PipelineRun(self.os, build_name)
+        return pipeline_run.any_task_failed()
+
+    @osbsapi
+    def build_has_any_cancelled_tasks(self, build_name):
+        pipeline_run = PipelineRun(self.os, build_name)
+        return pipeline_run.any_task_was_cancelled()
+
+    @osbsapi
     def get_build_annotations(self, build_name):
         pipeline_run = PipelineRun(self.os, build_name)
         return pipeline_run.annotations

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -964,6 +964,14 @@ class TestOSBS(object):
 
         assert output == osbs_binary.build_was_cancelled('run_name')
 
+    def test_build_has_any_failed_tasks(self, osbs_binary):
+        flexmock(PipelineRun).should_receive('any_task_failed').once().and_return(False)
+        assert not osbs_binary.build_has_any_failed_tasks('run_name')
+
+    def test_build_has_any_cancelled_tasks(self, osbs_binary):
+        flexmock(PipelineRun).should_receive('any_task_was_cancelled').once().and_return(False)
+        assert not osbs_binary.build_has_any_cancelled_tasks('run_name')
+
     def test_get_build_annotations(self, osbs_binary):
         annotations = {'some': 'ann1', 'some2': 'ann2'}
         resp = {'metadata': {'name': 'run_name', 'annotations': annotations}}


### PR DESCRIPTION
CLOUDBLD-10116

The existing has_succeeded(), was_cancelled() methods only work properly
for finished pipelineRuns (including finally tasks).

Atomic-reactor needs to check the status while the pipeline is still
running, i.e. check the status of non-finally tasks in the finally task.

Add API methods for this purpose.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
