### PR TITLE
handle missing 'terminated' key for tasksteps in get_error_message

### DIFF
--- a/osbs/tekton.py
+++ b/osbs/tekton.py
@@ -498,14 +498,19 @@ class PipelineRun():
 
             if 'steps' in stats['status']:
                 for step in stats['status']['steps']:
-                    exit_code = step['terminated']['exitCode']
-                    if exit_code == 0:
-                        continue
+                    if 'terminated' in step:
+                        exit_code = step['terminated']['exitCode']
+                        if exit_code == 0:
+                            continue
 
-                    reason = step['terminated']['reason']
-                    err_message += f"task step '{step['name']}' failed with exit " \
-                                   f"code: {exit_code} " \
-                                   f"and reason: '{reason}'"
+                        reason = step['terminated']['reason']
+                        err_message += f"task step '{step['name']}' failed with exit " \
+                                       f"code: {exit_code} " \
+                                       f"and reason: '{reason}'"
+                    else:
+                        err_message += f"task step '{step['name']}' is missing 'terminated' key " \
+                                       f"with exit code and reason"
+
             else:
                 task_condition = stats['status']['conditions'][0]
                 err_message += f"task run '{task_name}' failed with reason:" \

--- a/tests/test_tekton.py
+++ b/tests/test_tekton.py
@@ -456,6 +456,27 @@ class TestPipelineRun():
          "\npipeline task 'task1' failed:\ntask run 'task1' failed with reason: 'reason2' "
          "and message: 'message2'"),
 
+        # taskRuns in status, with steps and failed without terminated key
+        ({'status': {'conditions': [{'reason': 'reason1', 'message': 'message1'}],
+                     'taskRuns': {
+                         'task1': {
+                             'pipelineTaskName': 'binary-build-task1',
+                             'status': {
+                                 'conditions': [{'reason': 'reason2', 'message': 'message2'}],
+                                 'steps': [
+                                     {'name': 'step_ok',
+                                      'terminated': {'exitCode': 0}},
+                                     {'name': 'step_ko'},
+                                 ]
+                             }
+                         }
+                     }},
+          'metadata': {'annotations': {'plugins-metadata': '{"errors": {"plugin1": "error1",'
+                                                           '"plugin2": "error2"}}'}}},
+         "Error in plugin plugin1: error1\nError in plugin plugin2: error2\n\npipeline run errors:"
+         "\npipeline task 'task1' failed:\ntask step 'step_ko' is missing 'terminated' "
+         "key with exit code and reason"),
+
         # taskRuns in status, with steps
         ({'status': {'conditions': [{'reason': 'reason1', 'message': 'message1'}],
                      'taskRuns': {


### PR DESCRIPTION
* CLOUDBLD-9865

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
