### PR TITLE
save entire pipeline info in exported metadata

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -64,6 +64,7 @@ def _get_build_metadata(pipeline_run, user_warnings_store):
         "pipeline_run": {
             "name": pipeline_run.pipeline_run_name,
             "status": pipeline_run.status_reason,
+            "info": {}
         },
         "results": {
             "user_warnings": [],
@@ -73,7 +74,9 @@ def _get_build_metadata(pipeline_run, user_warnings_store):
     }
 
     if pipeline_run.has_succeeded():
-        annotations = pipeline_run.get_info()['metadata']['annotations']
+        info = pipeline_run.get_info()
+        output['pipeline_run']['info'] = info
+        annotations = info['metadata']['annotations']
         str_repositories = annotations.get('repositories', '{}')
         all_repositories = json.loads(str_repositories)
         output['results']['repositories'] = all_repositories

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -24,12 +24,7 @@ def test_print_output(tmpdir, capsys):
       * if STDOUT is correct
       * if JSON exported metadata are correct
     """
-    flexmock(time).should_receive('sleep').and_return(None)
-    ppln_run = flexmock(PipelineRun(flexmock(), 'test_ppln'))
-    (ppln_run
-     .should_receive('get_info')
-     .and_return(
-        {
+    test_metadata = {
             'metadata': {
                 'annotations': {
                     # annotations are JSON
@@ -41,7 +36,11 @@ def test_print_output(tmpdir, capsys):
                 }
             }
         }
-     ))
+    flexmock(time).should_receive('sleep').and_return(None)
+    ppln_run = flexmock(PipelineRun(flexmock(), 'test_ppln'))
+    (ppln_run
+     .should_receive('get_info')
+     .and_return(test_metadata))
     ppln_run.should_receive('has_succeeded').and_return(True)
     ppln_run.should_receive('status_reason').and_return('complete')
     ppln_run.should_receive('has_not_finished').and_return(False)
@@ -85,7 +84,8 @@ def test_print_output(tmpdir, capsys):
     expected_metadata = {
         'pipeline_run': {
             'name': 'test_ppln',
-            'status': 'complete'
+            'status': 'complete',
+            'info': test_metadata,
         },
         'results': {
             'error_msg': '',
@@ -159,7 +159,8 @@ def test_print_output_failure(tmpdir, capsys, get_logs_failed, build_not_finishe
     expected_metadata = {
         'pipeline_run': {
             'name': 'test_ppln',
-            'status': 'failed'
+            'status': 'failed',
+            'info': {},
         },
         'results': {
             'error_msg': 'Build failed ...',


### PR DESCRIPTION
* CLOUDBLD-10188

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
