### PR TITLE
Add api method to remove the build

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -438,6 +438,11 @@ class OSBS(object):
         return pipeline_run.cancel_pipeline_run()
 
     @osbsapi
+    def remove_build(self, build_name):
+        pipeline_run = PipelineRun(self.os, build_name)
+        return pipeline_run.remove_pipeline_run()
+
+    @osbsapi
     def update_annotations_on_build(self, build_name, annotations):
         pipeline_run = PipelineRun(self.os, build_name)
         return pipeline_run.update_annotations(annotations)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -987,6 +987,11 @@ class TestOSBS(object):
 
         assert resp == osbs_binary.cancel_build('run_name')
 
+    def test_remove_build(self, osbs_binary):
+        resp = {'kind': 'Status', 'apiVersion': 'v1', 'status': 'Success'}
+        flexmock(PipelineRun).should_receive('remove_pipeline_run').once().and_return(resp)
+        assert osbs_binary.remove_build('run_name') == resp
+
     def test_update_annotations(self, osbs_binary):
         annotations = {'some': 'ann1', 'some2': 'ann2'}
         resp = {'metadata': {'name': 'run_name', 'annotations': annotations}}


### PR DESCRIPTION
CLOUDBLD-10155

This will be used by koji-containerbuild to remove the build right after
it finishes.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
