### PR TITLE
Fix sorting key

### DIFF
--- a/osbs/tekton.py
+++ b/osbs/tekton.py
@@ -55,9 +55,22 @@ def check_response(response, log_level=logging.ERROR):
 
 
 def get_sorted_task_runs(task_runs: Dict[str, Any]) -> List[Tuple[str, Dict[str, Any]]]:
-    return sorted(task_runs.items(),
-                  key=lambda x: datetime.strptime(x[1]['status']['startTime'],
-                                                  '%Y-%m-%dT%H:%M:%SZ').timestamp())
+    def custom_key(x):
+        """
+        Handles cases where the startTime key is missing.
+        These items are put at the end.
+        """
+        missing_start_time = "startTime" not in x[1]["status"]
+        containing_start_time = (
+            datetime.strptime(
+                x[1]["status"]["startTime"], "%Y-%m-%dT%H:%M:%SZ"
+            ).timestamp()
+            if not missing_start_time
+            else None
+        )
+        return (missing_start_time, containing_start_time)
+
+    return sorted(task_runs.items(), key=custom_key)
 
 
 class Openshift(object):

--- a/tests/test_tekton.py
+++ b/tests/test_tekton.py
@@ -15,7 +15,7 @@ from copy import deepcopy
 from flexmock import flexmock
 
 from osbs.tekton import (Openshift, PipelineRun, TaskRun, Pod, API_VERSION, WAIT_RETRY_SECS,
-                         WAIT_RETRY)
+                         WAIT_RETRY, get_sorted_task_runs)
 from osbs.exceptions import OsbsException, OsbsValidationException
 from tests.constants import TEST_PIPELINE_RUN_TEMPLATE, TEST_OCP_NAMESPACE
 
@@ -1209,3 +1209,23 @@ class TestPipelineRun():
                         (task_run_3[TASK_RUN_NAME3]['pipelineTaskName'], '3Hello World'),
                         (task_run_3[TASK_RUN_NAME3]['pipelineTaskName'], '3'),
                         (task_run_3[TASK_RUN_NAME3]['pipelineTaskName'], '3Bye World')]
+
+
+def test_get_sorted_task_runs():
+    task_runs = {
+        "TaskRunSecond": {"status": {"startTime": "2022-09-07T18:23:51Z"}},
+        "TaskRunMissingKey": {"status": {}},
+        "TaskRunThird": {"status": {"startTime": "2022-09-07T18:24:51Z"}},
+        "TaskRunFirst": {"status": {"startTime": "2022-09-07T18:22:51Z"}},
+        "TaskRunMissingKeyAlso": {"status": {}},
+    }
+    expected_sorted = [
+        ("TaskRunFirst", {"status": {"startTime": "2022-09-07T18:22:51Z"}}),
+        ("TaskRunSecond", {"status": {"startTime": "2022-09-07T18:23:51Z"}}),
+        ("TaskRunThird", {"status": {"startTime": "2022-09-07T18:24:51Z"}}),
+        ("TaskRunMissingKey", {"status": {}}),
+        ("TaskRunMissingKeyAlso", {"status": {}}),
+    ]
+
+    actual_sorted = get_sorted_task_runs(task_runs)
+    assert actual_sorted == expected_sorted


### PR DESCRIPTION
There might be cases where the task runs do not
have the startTime, mostly just if they did not execute

I believe that this is the problem behind CLOUDBLD-10953

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
