### PR TITLE
when checking task states ignore tasks which don't have conditions in

### DIFF
--- a/osbs/tekton.py
+++ b/osbs/tekton.py
@@ -639,6 +639,11 @@ class PipelineRun():
 
         def matches_state(task_run: Dict[str, Any]) -> bool:
             task_run_status = task_run['status']
+            if 'conditions' not in task_run_status:
+                logger.debug('conditions are missing from status in task %s : %s',
+                             task_run['pipelineTaskName'], task_run_status)
+                return False
+
             status = task_run_status['conditions'][0]['status']
             reason = task_run_status['conditions'][0]['reason']
             completion_time = task_run_status.get('completionTime')


### PR DESCRIPTION
status, and log what is in status, this shouldn't happen but is sometimes happening

* CLOUDBLD-11209

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
