### PR TITLE
osbs1 cleanup

### DIFF
--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -129,7 +129,6 @@ class BuildCommon(BuildParamsBase):
         :param koji_parent_build: str,
         :param koji_target: str, koji tag with packages used to build the image
         :param koji_task_id: int, koji *task* ID
-        :param koji_upload_dir: str, koji directory where the completed image will be uploaded
         :param platform: str, platform
         :param scratch: bool, build as a scratch build (if not specified in build_conf)
         :param signing_intent: bool, True to sign the resulting image
@@ -249,7 +248,6 @@ class BuildUserParams(BuildCommon):
     base_image = BuildParam("base_image")
     compose_ids = BuildParam("compose_ids")
     dependency_replacements = BuildParam("dependency_replacements")
-    filesystem_koji_task_id = BuildParam("filesystem_koji_task_id")
     flatpak = BuildParam("flatpak", default=False)
     git_branch = BuildParam("git_branch")
     git_commit_depth = BuildParam("git_commit_depth")
@@ -258,12 +256,8 @@ class BuildUserParams(BuildCommon):
     include_koji_repo = BuildParam("include_koji_repo", default=False)
     isolated = BuildParam("isolated")
     koji_parent_build = BuildParam("koji_parent_build")
-    koji_upload_dir = BuildParam("koji_upload_dir")
     name = BuildIDParam()
-    operator_bundle_replacement_pullspecs = BuildParam("operator_bundle_replacement_pullspecs")
     operator_csv_modifications_url = BuildParam("operator_csv_modifications_url")
-    operator_manifests_extract_platform = BuildParam("operator_manifests_extract_platform")
-    parent_images_digests = BuildParam("parent_images_digests")
     platforms = BuildParam("platforms")
     release = BuildParam("release")
     remote_sources = BuildParam("remote_sources")
@@ -277,7 +271,6 @@ class BuildUserParams(BuildCommon):
                     build_conf=None,
                     compose_ids=None,
                     dependency_replacements=None,
-                    filesystem_koji_task_id=None,
                     flatpak=None,
                     git_branch=None,
                     git_commit_depth=None,
@@ -286,12 +279,8 @@ class BuildUserParams(BuildCommon):
                     include_koji_repo=None,
                     isolated=None,
                     koji_parent_build=None,
-                    koji_upload_dir=None,
                     name_label=None,
-                    operator_bundle_replacement_pullspecs=None,
                     operator_csv_modifications_url=None,
-                    operator_manifests_extract_platform=None,
-                    parent_images_digests=None,
                     platform=None,
                     platforms=None,
                     release=None,
@@ -313,7 +302,6 @@ class BuildUserParams(BuildCommon):
         :param compose_ids: list of int, ODCS composes to use instead of generating new ones
         :param dependency_replacements: list of str, dependencies to be replaced by cachito, as
         pkg_manager:name:version[:new_name]
-        :param filesystem_koji_task_id: int, Koji Task that created the base filesystem
         :param flatpak: if we should build a Flatpak OCI Image
         :param git_branch: str, branch name of the branch to be pulled
         :param git_ref: str, commit ID of the branch to be pulled
@@ -322,16 +310,9 @@ class BuildUserParams(BuildCommon):
                                                    repourls are provided.
         :param isolated: bool, build as an isolated build
         :param koji_parent_build: str,
-        :param koji_upload_dir: str, koji directory where the completed image will be uploaded
         :param name_label: str, label of the parent image
         :param user: str, name of the user requesting the build
-        :param operator_bundle_replacement_pullspecs: dict, mapping of original pullspecs to
-                                                      replacement pullspecs for operator manifest
-                                                      bundle builds
         :param operator_csv_modifications_url: str, URL to JSON file describing operator CSV changes
-        :param operator_manifests_extract_platform: str, indicates which platform should upload
-                                                    operator manifests to koji
-        :param parent_images_digests: dict, mapping image digests to names and platforms
         :param platforms: list of str, platforms to build on
         :param platform: str, platform
         :param reactor_config_map: str, name of the config map containing the reactor environment
@@ -391,16 +372,11 @@ class BuildUserParams(BuildCommon):
             "build_conf": build_conf,
             "compose_ids": compose_ids or [],
             "dependency_replacements": dependency_replacements or [],
-            "filesystem_koji_task_id": filesystem_koji_task_id,
             "flatpak": flatpak,
             "include_koji_repo": include_koji_repo,
             "isolated": isolated,
             "koji_parent_build": koji_parent_build,
-            "koji_upload_dir": koji_upload_dir,
-            "operator_bundle_replacement_pullspecs": operator_bundle_replacement_pullspecs,
             "operator_csv_modifications_url": operator_csv_modifications_url,
-            "operator_manifests_extract_platform": operator_manifests_extract_platform,
-            "parent_images_digests": parent_images_digests,
             "platform": platform,
             "platforms": platforms,
             "release": release,

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -118,7 +118,6 @@ def cmd_build(args):
         'git_ref': osbs.os_conf.get_git_ref(),
         'git_branch': osbs.os_conf.get_git_branch(),
         'user': osbs.os_conf.get_user(),
-        'tag': osbs.os_conf.get_tag(),
         'target': osbs.os_conf.get_koji_target(),
         'yum_repourls': osbs.os_conf.get_yum_repourls(),
         'dependency_replacements': osbs.os_conf.get_dependency_replacements(),
@@ -262,8 +261,6 @@ def cli():
                               help="prefix for docker image repository")
     build_parser.add_argument("-c", "--component", action='store', required=False,
                               help="not used; use com.redhat.component label in Dockerfile")
-    build_parser.add_argument("-A", "--tag", action='store', required=False,
-                              help="tag of the built image (simple builds only)")
     build_parser.add_argument("--add-yum-repo", action='append', metavar="URL",
                               dest="yum_repourls", help="URL of yum repo file")
     build_parser.add_argument("--scratch", action='store_true', required=False,

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -167,9 +167,6 @@ class Configuration(object):
         """ user namespace when tagging and pushing image """
         return self._get_value("user", self.conf_section, "user")
 
-    def get_tag(self):
-        return self._get_value("tag", self.conf_section, "tag")
-
     def get_yum_repourls(self):
         return self._get_value("yum_repourls", self.conf_section, "yum_repourls")
 

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -24,8 +24,7 @@ from osbs.build.user_params import (
 from osbs.conf import Configuration
 from osbs.repo_utils import RepoInfo, RepoConfiguration
 from osbs.exceptions import OsbsValidationException
-from tests.constants import (TEST_COMPONENT, TEST_FILESYSTEM_KOJI_TASK_ID,
-                             TEST_GIT_BRANCH, TEST_GIT_REF, TEST_GIT_URI,
+from tests.constants import (TEST_COMPONENT, TEST_GIT_BRANCH, TEST_GIT_REF, TEST_GIT_URI,
                              TEST_KOJI_TASK_ID, TEST_USER)
 import osbs.utils
 
@@ -206,7 +205,6 @@ class TestBuildUserParams(object):
             'base_image': 'buildroot:old',
             'component': TEST_COMPONENT,
             'compose_ids': [1, 2],
-            'filesystem_koji_task_id': TEST_FILESYSTEM_KOJI_TASK_ID,
             'flatpak': False,
             # 'flatpak_base_image': self.flatpak_base_image,  # not used with false flatpack
             # 'git_branch': TEST_GIT_BRANCH,
@@ -217,16 +215,7 @@ class TestBuildUserParams(object):
             'isolated': False,
             'koji_parent_build': 'fedora-26-9',
             'koji_target': 'tothepoint',
-            'operator_bundle_replacement_pullspecs': {
-                'foo/fedora:30': 'bar/fedora@sha256:deadbeef'
-            },
             # "orchestrator_deadline": 4,  # set in config
-            'parent_images_digests': {
-                'registry.fedorahosted.org/fedora:29': {
-                    'x86_64': 'registry.fedorahosted.org/fedora@sha256:8b96f2f9f88179a065738b2b37'
-                              '35e386efb2534438c2a2f45b74358c0f344c81'
-                }
-            },
             # 'name': self.name,  # calculated value
             'platform': 'x86_64',
             'platforms': ['x86_64', ],
@@ -266,7 +255,6 @@ class TestBuildUserParams(object):
             "base_image": "buildroot:old",
             "component": TEST_COMPONENT,
             "compose_ids": [1, 2],
-            "filesystem_koji_task_id": TEST_FILESYSTEM_KOJI_TASK_ID,
             "include_koji_repo": True,
             "git_branch": TEST_GIT_BRANCH,
             "git_ref": TEST_GIT_REF,
@@ -277,15 +265,6 @@ class TestBuildUserParams(object):
             "koji_parent_build": "fedora-26-9",
             "koji_target": "tothepoint",
             "name": "path-master-cd1e4" + f'{rand}-{timestr}',
-            'operator_bundle_replacement_pullspecs': {
-                'foo/fedora:30': 'bar/fedora@sha256:deadbeef'
-            },
-            'parent_images_digests': {
-                'registry.fedorahosted.org/fedora:29': {
-                    'x86_64': 'registry.fedorahosted.org/fedora@sha256:8b96f2f9f88179a065738b2b37'
-                              '35e386efb2534438c2a2f45b74358c0f344c81'
-                }
-            },
             "platform": "x86_64",
             "platforms": ["x86_64"],
             "release": "29",
@@ -312,7 +291,6 @@ class TestBuildUserParams(object):
             "component": TEST_COMPONENT,
             "compose_ids": [1, 2],
             "customize_conf": "prod_customize.json",
-            "filesystem_koji_task_id": TEST_FILESYSTEM_KOJI_TASK_ID,
             "git_branch": TEST_GIT_BRANCH,
             "git_ref": TEST_GIT_REF,
             "git_uri": TEST_GIT_URI,

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -38,7 +38,6 @@ TEST_BUILD_POD = "build-test-build-123"
 TEST_LABEL = "test-label"
 TEST_LABEL_VALUE = "sample-value"
 TEST_KOJI_TASK_ID = 12345
-TEST_FILESYSTEM_KOJI_TASK_ID = 67890
 TEST_KOJI_BUILD_ID = 1234567
 TEST_KOJI_BUILD_NVR = TEST_KOJI_NAME + "-" + TEST_VERSION + "-" + TEST_KOJI_RELEASE
 TEST_DOCKERFILE_GIT = "https://github.com/TomasTomecek/docker-hello-world.git"


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
