### PR TITLE
allow user to configure build time for binary pipeline

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -122,6 +122,8 @@ def cmd_build(args):
         'target': osbs.os_conf.get_koji_target(),
         'yum_repourls': osbs.os_conf.get_yum_repourls(),
         'dependency_replacements': osbs.os_conf.get_dependency_replacements(),
+        'default_buildtime_limit': osbs.os_conf.get_default_buildtime_limit(),
+        'max_buildtime_limit': osbs.os_conf.get_max_buildtime_limit(),
         'scratch': args.scratch,
         'platforms': args.platforms,
         'release': args.release,

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -216,6 +216,14 @@ class Configuration(object):
         return self._get_value("cleanup_used_resources", self.conf_section,
                                "cleanup_used_resources", default=True, is_bool_val=True)
 
+    def get_default_buildtime_limit(self):
+        return int(self._get_value("default_buildtime_limit", self.conf_section,
+                                   "default_buildtime_limit", default=10800))
+
+    def get_max_buildtime_limit(self):
+        return int(self._get_value("max_buildtime_limit", self.conf_section,
+                                   "max_buildtime_limit", default=21600))
+
     def get_verify_ssl(self):
         return self._get_value("verify_ssl", self.conf_section, "verify_ssl",
                                default=True, is_bool_val=True)

--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -144,6 +144,7 @@ class RepoConfiguration(object):
                                 " will be ignored")
             del self.container['image_build_method']
 
+        self.buildtime_limit = self.container.get('buildtime_limit', 0)
         # container values may be set to None
         container_compose = self.container.get('compose') or {}
         modules = container_compose.get('modules') or []

--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -9,6 +9,7 @@
       "properties": {
         "platforms": {"$ref": "#/definitions/all_platforms"},
         "autorebuild": {"$ref": "#/definitions/autorebuild"},
+        "buildtime_limit": {"$ref": "#/definitions/buildtime_limit"},
         "compose": {"$ref": "#/definitions/compose"},
         "flatpak": {"$ref": "#/definitions/flatpak"},
         "operator_manifests": {"$ref": "#/definitions/operator_manifests"},
@@ -24,6 +25,7 @@
       "properties": {
         "platforms": {"$ref": "#/definitions/all_platforms"},
         "autorebuild": {"$ref": "#/definitions/autorebuild"},
+        "buildtime_limit": {"$ref": "#/definitions/buildtime_limit"},
         "compose": {"$ref": "#/definitions/compose"},
         "flatpak": {"$ref": "#/definitions/flatpak"},
         "operator_manifests": {"$ref": "#/definitions/operator_manifests"},
@@ -39,6 +41,7 @@
       "properties": {
         "platforms": {"$ref": "#/definitions/all_platforms"},
         "autorebuild": {"$ref": "#/definitions/autorebuild"},
+        "buildtime_limit": {"$ref": "#/definitions/buildtime_limit"},
         "compose": {"$ref": "#/definitions/compose"},
         "flatpak": {"$ref": "#/definitions/flatpak"},
         "operator_manifests": {"$ref": "#/definitions/operator_manifests"},
@@ -105,6 +108,16 @@
       },
       "additionalProperties": false,
       "deprecated": true
+    },
+    "buildtime_limit": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Build time limit in seconds, it must be within a certain range that is preconfigured",
+      "examples": [
+        15000,
+        17000,
+        21600
+      ]
     },
     "compose": {
       "type": ["object", "null"],

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -277,6 +277,38 @@ class TestConfiguration(object):
 
             assert conf.get_cleanup_used_resources() == expected
 
+    @pytest.mark.parametrize(('config', 'expected'), [
+        ({
+             'default': {'default_buildtime_limit': 1500},
+         }, 1500),
+        ({
+             'default': {'default_buildtime_limit': 2500},
+         }, 2500),
+        ({
+             'default': {},
+         }, 10800),
+    ])
+    def test_default_buildtime_limit(self, config, expected):
+        with self.config_file(config) as config_file:
+            conf = Configuration(conf_file=config_file, conf_section='default')
+        assert conf.get_default_buildtime_limit() == expected
+
+    @pytest.mark.parametrize(('config', 'expected'), [
+        ({
+             'default': {'max_buildtime_limit': 1500},
+         }, 1500),
+        ({
+             'default': {'max_buildtime_limit': 2500},
+         }, 2500),
+        ({
+             'default': {},
+         }, 21600),
+    ])
+    def test_max_buildtime_limit(self, config, expected):
+        with self.config_file(config) as config_file:
+            conf = Configuration(conf_file=config_file, conf_section='default')
+        assert conf.get_max_buildtime_limit() == expected
+
     def test_deprecated_warnings(self, caplog):  # noqa:F811
         with caplog.at_level(logging.WARNING):
             assert "it has been deprecated" not in caplog.text


### PR DESCRIPTION
* CLOUDBLD-9913

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
