### PR TITLE
pipelineResults aren't anymore always json strings

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 flexmock>=0.11.0
+urllib3<1.26
 pytest>=4.1.0
 pytest-cov
 pytest-html

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1055,10 +1055,14 @@ class TestOSBS(object):
         error_msg += "Error in prun-task2: bad thing;\n"
         assert error_msg == osbs_binary.get_build_error_message('run_name')
 
-    def test_get_final_platforms(self, osbs_binary):
+    @pytest.mark.parametrize('platforms_result', [
+        '["x86_64", "ppc64le"]',
+        ["x86_64", "ppc64le"],
+    ])
+    def test_get_final_platforms(self, osbs_binary, platforms_result):
         taskruns = {'task1': {'status': {'conditions': [{'reason': 'Succeeded'}],
                                          'taskResults': [{'name': 'platforms_result',
-                                                          'value': '["x86_64", "ppc64le"]'}],
+                                                          'value': platforms_result}],
                                          'startTime': '2022-04-26T15:58:42Z'},
                               'pipelineTaskName': 'binary-container-prebuild'}}
 


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
