### PR TITLE
pin deps to python3.6 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ requests
 requests-kerberos
 six
 PyYAML
-opentelemetry-api==1.19.0
-opentelemetry-exporter-otlp==1.19.0
-opentelemetry-instrumentation-requests==0.40b0
-opentelemetry-sdk==1.19.0
+opentelemetry-api==1.12.0
+opentelemetry-exporter-otlp==1.12.0
+opentelemetry-instrumentation-requests==0.33b0
+opentelemetry-sdk==1.12.0
 otel-extensions


### PR DESCRIPTION
We are using python3.6 in testing setup
and some deps are not available beyond
certain version for python3.6

This might cause issue with python3.6 where
latest versions are not available

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
