### PR TITLE
Add remote_sources_version into container.yaml

### DIFF
--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -17,6 +17,7 @@
         "tags": {"$ref": "#/definitions/tags"},
         "set_release_env": {"$ref": "#/definitions/set_release_env"},
         "version": {"$ref": "#/definitions/version"},
+        "remote_sources_version": {"$ref": "#/definitions/remote_sources_version"},
         "go": {"$ref": "#/definitions/go"}
       },
       "additionalProperties": false
@@ -33,6 +34,7 @@
         "tags": {"$ref": "#/definitions/tags"},
         "set_release_env": {"$ref": "#/definitions/set_release_env"},
         "version": {"$ref": "#/definitions/version"},
+        "remote_sources_version": {"$ref": "#/definitions/remote_sources_version"},
         "remote_source": {"$ref": "#/definitions/remote_source"}
       },
       "additionalProperties": false
@@ -49,6 +51,7 @@
         "tags": {"$ref": "#/definitions/tags"},
         "set_release_env": {"$ref": "#/definitions/set_release_env"},
         "version": {"$ref": "#/definitions/version"},
+        "remote_sources_version": {"$ref": "#/definitions/remote_sources_version"},
         "remote_sources": {"$ref": "#/definitions/remote_sources"}
       },
       "additionalProperties": false
@@ -438,6 +441,14 @@
         }
       },
       "additionalProperties": false
+    },
+    "remote_sources_version": {
+      "type": "number",
+      "description": "Feature version of remote sources",
+      "examples": [1, 2],
+      "minimum": 1,
+      "maximum": 2,
+      "default": 1
     }
   }
 }

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -303,6 +303,14 @@ def test_validate_with_schema_bad_schema(caplog):
             ),
             r"Additional properties are not allowed \('additional_property' was unexpected\)",
         ),
+        (
+            (
+             """
+             remote_sources_version: 40
+             """
+            ),
+            r"40 is greater than the maximum of 2",
+        ),
     ],
 )
 def test_invalid_remote_sources_schema(config, err_message, caplog):


### PR DESCRIPTION
This will allow users to pick version fo remote_sources feature which should be used.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
