### PR TITLE
Limit allowed pkg_managers

### DIFF
--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -348,6 +348,7 @@
           "type": ["array", "null"],
           "items": {
               "type": "string",
+              "enum": ["gomod", "rubygems", "pip", "yarn", "npm", "git-submodule"],
               "examples": [
                 "gomod"
               ]

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -360,3 +360,43 @@ def test_invalid_remote_sources_schema(config, err_message, caplog):
 def test_valid_remote_sources_schema(config, expected_data):
     data = read_yaml(dedent(config), "schemas/container.json")
     assert expected_data == data
+
+
+@pytest.mark.parametrize("pkg_manager,valid", [
+    ("npm", True),
+    ("pip", True),
+    ("gomod", True),
+    ("git-submodule", True),
+    ("yarn", True),
+    ("rubygems", True),
+    ("generic", False),
+    ("rpm", False),
+])
+def test_valid_pkg_managers(pkg_manager, valid):
+    remote_sources = f"""
+        remote_sources:
+        - name: valid-name
+          remote_source:
+            repo: https://git.example.com/team/repo.git
+            ref: b55c00f45ec3dfee0c766cea3d395d6e21cc2e5a
+            pkg_managers:
+                - {pkg_manager}
+        """
+    if valid:
+        assert read_yaml(dedent(remote_sources), "schemas/container.json")
+    else:
+        with pytest.raises(OsbsValidationException):
+            read_yaml(dedent(remote_sources), "schemas/container.json")
+
+    remote_source = f"""
+        remote_source:
+          repo: https://git.example.com/team/repo.git
+          ref: b55c00f45ec3dfee0c766cea3d395d6e21cc2e5a
+          pkg_managers:
+            - {pkg_manager}
+    """
+    if valid:
+        read_yaml(dedent(remote_source), "schemas/container.json")
+    else:
+        with pytest.raises(OsbsValidationException):
+            read_yaml(dedent(remote_source), "schemas/container.json")


### PR DESCRIPTION
CAchito and cachi2 should support the same set of pkg managers.

Cachi2 allows more pkg managers, but those must be tested and implemented in OSBS as they may interact with existing workflows.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
